### PR TITLE
#220 empty language attribute fix

### DIFF
--- a/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
+++ b/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
@@ -46,7 +46,7 @@ object AudioApiProperties extends LazyLogging {
   val SearchDocument = "audio"
   val DefaultPageSize = 10
   val MaxPageSize = 100
-  val IndexBulkSize = 1000
+  val IndexBulkSize = 200
 
   val MigrationHost = prop("MIGRATION_HOST")
   val MigrationUser = prop("MIGRATION_USER")

--- a/src/main/scala/no/ndla/audioapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/package.scala
@@ -2,7 +2,6 @@ package no.ndla.audioapi.model
 
 package object domain {
 
-  def emptySomeToNone(lang: Option[String]): Option[String] = {
-    lang.filter(_.nonEmpty)
-  }
+  def emptySomeToNone(lang: Option[String]): Option[String] = lang.filter(_.nonEmpty)
+
 }

--- a/src/main/scala/no/ndla/audioapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/package.scala
@@ -1,0 +1,8 @@
+package no.ndla.audioapi.model
+
+package object domain {
+
+  def emptySomeToNone(lang: Option[String]): Option[String] = {
+    lang.filter(_.nonEmpty)
+  }
+}

--- a/src/main/scala/no/ndla/audioapi/model/search/SearchableAudioInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/search/SearchableAudioInformation.scala
@@ -8,14 +8,26 @@
 
 package no.ndla.audioapi.model.search
 
-case class LanguageValue[T](lang: Option[String], value: T)
+import no.ndla.audioapi.model.domain.emptySomeToNone
+import no.ndla.audioapi.model.search.LanguageValue.LanguageValue
+
+object LanguageValue {
+
+  case class LanguageValue[T](lang: Option[String], value: T)
+
+  def apply[T](lang: Option[String], value: T): LanguageValue[T] = LanguageValue(emptySomeToNone(lang), value)
+
+}
+
 
 case class SearchableLanguageValues(languageValues: Seq[LanguageValue[String]])
 
 case class SearchableLanguageList(languageValues: Seq[LanguageValue[Seq[String]]])
 
-case class SearchableAudioInformation(id: String,
-                                      titles: SearchableLanguageValues,
-                                      tags: SearchableLanguageList,
-                                      license: String,
-                                      authors: Seq[String])
+case class SearchableAudioInformation(
+  id: String,
+  titles: SearchableLanguageValues,
+  tags: SearchableLanguageList,
+  license: String,
+  authors: Seq[String]
+)


### PR DESCRIPTION
Fikser at indexeringen feiler fordi language ikke er satt og dermed ble til en tom Some() istedet for en None. Gjør det samme som ble gjort i learningpath-api. 