### PR TITLE
NDLANO/Issues#580 pagination over 10000 results

### DIFF
--- a/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
+++ b/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
@@ -56,6 +56,7 @@ object AudioApiProperties extends LazyLogging {
 
   val IsoMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
   val LicenseMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
+  val ElasticSearchIndexMaxResultWindow = 10000
 
   val AudioFilesUrlSuffix = "audio/files"
 

--- a/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
@@ -17,7 +17,7 @@ import org.json4s.{DefaultFormats, Formats}
 import org.scalatra._
 import org.scalatra.json.NativeJsonSupport
 import no.ndla.audioapi.AudioApiProperties.{CorrelationIdHeader, CorrelationIdKey}
-import no.ndla.audioapi.model.api.{AccessDeniedException, Error, ValidationError, ValidationException, ValidationMessage}
+import no.ndla.audioapi.model.api.{AccessDeniedException, Error, ResultWindowTooLargeException, ValidationError, ValidationException, ValidationMessage}
 import no.ndla.network.model.HttpRequestException
 import org.scalatra.servlet.SizeConstraintExceededException
 
@@ -46,6 +46,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
     case a: AccessDeniedException => Forbidden(body = Error(Error.ACCESS_DENIED, a.getMessage))
     case v: ValidationException => BadRequest(body=ValidationError(messages=v.errors))
     case hre: HttpRequestException => BadGateway(Error(Error.REMOTE_ERROR, hre.getMessage))
+    case rw: ResultWindowTooLargeException => UnprocessableEntity(body=Error(Error.WINDOW_TOO_LARGE, rw.getMessage))
     case _: SizeConstraintExceededException =>
       contentType = formats("json")
       RequestEntityTooLarge(body=Error.FileTooBigError)

--- a/src/main/scala/no/ndla/audioapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Error.scala
@@ -29,10 +29,12 @@ object Error {
   val VALIDATION = "VALIDATION_ERROR"
   val FILE_TOO_BIG = "FILE TOO BIG"
   val ACCESS_DENIED = "ACCESS DENIED"
+  val WINDOW_TOO_LARGE = "RESULT_WINDOW_TOO_LARGE"
 
   val RESOURCE_OUTDATED_DESCRIPTION = "The resource is outdated. Please try fetching before submitting again."
   val GENERIC_DESCRIPTION = s"Ooops. Something we didn't anticipate occured. We have logged the error, and will look into it. But feel free to contact ${AudioApiProperties.ContactEmail} if the error persists."
   val FileTooBigError = Error(FILE_TOO_BIG, s"The file is too big. Max file size is ${AudioApiProperties.MaxAudioFileSizeBytes / 1024 / 1024} MiB")
+  val WINDOW_TOO_LARGE_DESCRIPTION = s"The result window is too large. Fetching pages above ${AudioApiProperties.ElasticSearchIndexMaxResultWindow} results are unsupported."
 }
 
 class NotFoundException(message: String = "The audio was not found") extends RuntimeException(message)
@@ -42,3 +44,4 @@ class OptimisticLockException(message: String = Error.RESOURCE_OUTDATED_DESCRIPT
 case class ValidationMessage(field: String, message: String)
 class AudioStorageException(message: String) extends RuntimeException(message)
 class LanguageMappingException(message: String) extends RuntimeException(message)
+class ResultWindowTooLargeException(message: String = Error.WINDOW_TOO_LARGE_DESCRIPTION) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
@@ -70,7 +70,10 @@ trait IndexService {
       if (indexExists(indexName).getOrElse(false)) {
         Success(indexName)
       } else {
-        val createIndexResponse = jestClient.execute(new CreateIndex.Builder(indexName).build())
+        val createIndexResponse = jestClient.execute(
+          new CreateIndex.Builder(indexName)
+            .settings(s"""{"index":{"max_result_window":${AudioApiProperties.ElasticSearchIndexMaxResultWindow}}}""")
+            .build())
         createIndexResponse.map(_ => createMapping(indexName)).map(_ => indexName)
       }
     }


### PR DESCRIPTION
- Setter `index.max_result_window` verdien i elasticsearch når index'er lages
- Error handling når det requestes pages etter `index.max_result_window` results