### PR TITLE
#2226: Only create initial scroll-context when provided with '0', 'start', 'first' or 'initial'

### DIFF
--- a/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
+++ b/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
@@ -65,7 +65,8 @@ object AudioApiProperties extends LazyLogging {
   val IsoMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
   val LicenseMappingCacheAgeInMs = 1000 * 60 * 60 // 1 hour caching
   val ElasticSearchIndexMaxResultWindow = 10000
-  val ElasticSearchScrollKeepAlive = "10s"
+  val ElasticSearchScrollKeepAlive = "1m"
+  val InitialScrollContextKeywords = List("0", "initial", "start", "first")
 
   val AudioFilesUrlSuffix = "audio/files"
 

--- a/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -104,14 +104,12 @@ trait AudioController {
 
     private val scrollId = Param[Option[String]](
       "search-context",
-      s"""A search context retrieved from the response header of a previous search.
-         |To get the initial one from a search supply search-context equal any of the following ${InitialScrollContextKeywords
+      s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
            .mkString("[", ",", "]")}.
-         |If search-context is specified, all other query parameters, except '${this.language.paramName}' are ignored
-         |For the rest of the parameters the original search of the search-context is used.
-         |The search context may change between scrolls. Always use the most recent one (The context if unused dies after $ElasticSearchScrollKeepAlive).
-         |Used to enable scrolling past $ElasticSearchIndexMaxResultWindow results.
-      """.stripMargin
+         |When scrolling the parameters from the initial search is used, except in the case of '${this.language.paramName}'.
+         |The value may change between scrolls. Always use the one in the latest scroll result (The context if unused dies after $ElasticSearchScrollKeepAlive).
+         |If you are not scrolling past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
+         |""".stripMargin
     )
 
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =

--- a/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -106,9 +106,9 @@ trait AudioController {
       "search-context",
       s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
            .mkString("[", ",", "]")}.
-         |When scrolling the parameters from the initial search is used, except in the case of '${this.language.paramName}'.
-         |The value may change between scrolls. Always use the one in the latest scroll result (The context if unused dies after $ElasticSearchScrollKeepAlive).
-         |If you are not scrolling past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
+         |When scrolling, the parameters from the initial search is used, except in the case of '${this.language.paramName}'.
+         |This value may change between scrolls. Always use the one in the latest scroll result (The context, if unused, dies after $ElasticSearchScrollKeepAlive).
+         |If you are not paginating past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
          |""".stripMargin
     )
 

--- a/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
@@ -8,5 +8,6 @@ case class SearchSettings(
     license: Option[String],
     page: Option[Int],
     pageSize: Option[Int],
-    sort: Sort.Value
+    sort: Sort.Value,
+    shouldScroll: Boolean
 )

--- a/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
@@ -1,0 +1,12 @@
+package no.ndla.audioapi.model.domain
+
+import no.ndla.audioapi.model.Sort
+
+case class SearchSettings(
+    query: Option[String],
+    language: Option[String],
+    license: Option[String],
+    page: Option[Int],
+    pageSize: Option[Int],
+    sort: Sort.Value
+)

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
@@ -19,7 +19,7 @@ import no.ndla.audioapi.AudioApiProperties.{ElasticSearchIndexMaxResultWindow, E
 import no.ndla.audioapi.integration.Elastic4sClient
 import no.ndla.audioapi.model.Language._
 import no.ndla.audioapi.model.api.{AudioSummary, ResultWindowTooLargeException, SearchResult, Title}
-import no.ndla.audioapi.model.domain.NdlaSearchException
+import no.ndla.audioapi.model.domain.{NdlaSearchException, SearchSettings}
 import no.ndla.audioapi.model.{Language, Sort, domain}
 import no.ndla.network.ApplicationUrl
 import org.elasticsearch.ElasticsearchException
@@ -94,28 +94,20 @@ trait SearchService {
       )
     }
 
-    def all(language: Option[String],
-            license: Option[String],
-            page: Option[Int],
-            pageSize: Option[Int],
-            sort: Sort.Value): Try[domain.SearchResult] = {
-      executeSearch(language, license, sort, page, pageSize, boolQuery())
-    }
+    def matchingQuery(settings: SearchSettings): Try[domain.SearchResult] = {
 
-    def matchingQuery(query: String,
-                      language: Option[String],
-                      license: Option[String],
-                      page: Option[Int],
-                      pageSize: Option[Int],
-                      sort: Sort.Value): Try[domain.SearchResult] = {
-      val fullSearch = boolQuery()
-        .must(
+      val fullSearch = settings.query match {
+        case Some(query) =>
           boolQuery()
-            .should(languageSpecificSearch("titles", language, query, 2),
-                    languageSpecificSearch("tags", language, query, 1),
-                    idsQuery(query)))
+            .must(
+              boolQuery()
+                .should(languageSpecificSearch("titles", settings.language, query, 2),
+                        languageSpecificSearch("tags", settings.language, query, 1),
+                        idsQuery(query)))
+        case None => boolQuery()
+      }
 
-      executeSearch(language, license, sort, page, pageSize, fullSearch)
+      executeSearch(settings, fullSearch)
     }
 
     private def languageSpecificSearch(searchField: String,
@@ -132,19 +124,14 @@ trait SearchService {
       }
     }
 
-    def executeSearch(language: Option[String],
-                      license: Option[String],
-                      sort: Sort.Value,
-                      page: Option[Int],
-                      pageSize: Option[Int],
-                      queryBuilder: BoolQuery): Try[domain.SearchResult] = {
+    def executeSearch(settings: SearchSettings, queryBuilder: BoolQuery): Try[domain.SearchResult] = {
 
-      val licenseFilter = license match {
+      val licenseFilter = settings.license match {
         case None      => Some(boolQuery().not(termQuery("license", "copyrighted")))
         case Some(lic) => Some(termQuery("license", lic))
       }
 
-      val (languageFilter, searchLanguage) = language match {
+      val (languageFilter, searchLanguage) = settings.language match {
         case None | Some(Language.AllLanguages) => (None, "*")
         case Some(lang)                         => (Some(nestedQuery("titles", existsQuery(s"titles.$lang")).scoreMode(ScoreMode.Avg)), lang)
       }
@@ -152,8 +139,8 @@ trait SearchService {
       val filters = List(licenseFilter, languageFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
-      val (startAt, numResults) = getStartAtAndNumResults(page, pageSize)
-      val requestedResultWindow = page.getOrElse(1) * numResults
+      val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)
+      val requestedResultWindow = settings.page.getOrElse(1) * numResults
       if (requestedResultWindow > ElasticSearchIndexMaxResultWindow) {
         logger.info(
           s"Max supported results are $ElasticSearchIndexMaxResultWindow, user requested $requestedResultWindow")
@@ -166,7 +153,7 @@ trait SearchService {
             .from(startAt)
             .query(filteredSearch)
             .highlighting(highlight("*"))
-            .sortBy(getSortDefinition(sort, searchLanguage))
+            .sortBy(getSortDefinition(settings.sort, searchLanguage))
 
         // Only add scroll param if it is first page
         val searchWithScroll =
@@ -177,7 +164,7 @@ trait SearchService {
             Success(
               domain.SearchResult(
                 response.result.totalHits,
-                Some(page.getOrElse(1)),
+                Some(settings.page.getOrElse(1)),
                 numResults,
                 if (searchLanguage == "*") Language.AllLanguages else searchLanguage,
                 getHits(response.result, searchLanguage),
@@ -198,20 +185,20 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.ASC).missing("_last")
-            case _   => fieldSort(s"titles.$sortLanguage.raw").nestedPath("titles").order(SortOrder.ASC).missing("_last")
+            case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.Asc).missing("_last")
+            case _   => fieldSort(s"titles.$sortLanguage.raw").nestedPath("titles").order(SortOrder.Asc).missing("_last")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.DESC).missing("_last")
-            case _   => fieldSort(s"titles.$sortLanguage.raw").nestedPath("titles").order(SortOrder.DESC).missing("_last")
+            case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.Desc).missing("_last")
+            case _   => fieldSort(s"titles.$sortLanguage.raw").nestedPath("titles").order(SortOrder.Desc).missing("_last")
           }
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.DESC)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.ASC).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.DESC).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.ASC).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.DESC).missing("_last")
+        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
+        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
+        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
+        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
+        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
+        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
@@ -157,7 +157,9 @@ trait SearchService {
 
         // Only add scroll param if it is first page
         val searchWithScroll =
-          if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
+          if (startAt == 0 && settings.shouldScroll) {
+            searchToExecute.scroll(ElasticSearchScrollKeepAlive)
+          } else { searchToExecute }
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>

--- a/src/test/scala/no/ndla/audioapi/controller/AudioControllerTest.scala
+++ b/src/test/scala/no/ndla/audioapi/controller/AudioControllerTest.scala
@@ -9,6 +9,7 @@
 package no.ndla.audioapi.controller
 
 import no.ndla.audioapi.model.api._
+import no.ndla.audioapi.model.domain.SearchSettings
 import no.ndla.audioapi.model.{Sort, domain}
 import no.ndla.audioapi.{AudioSwagger, TestEnvironment, UnitSuite}
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
@@ -127,15 +128,7 @@ class AudioControllerTest extends UnitSuite with ScalatraSuite with TestEnvironm
       Seq.empty,
       Some(scrollId)
     )
-    when(
-      searchService.all(
-        any[Option[String]],
-        any[Option[String]],
-        any[Option[Int]],
-        any[Option[Int]],
-        any[Sort.Value]
-      ))
-      .thenReturn(Success(searchResponse))
+    when(searchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchResponse))
 
     get(s"/") {
       status should be(200)
@@ -163,21 +156,7 @@ class AudioControllerTest extends UnitSuite with ScalatraSuite with TestEnvironm
       status should be(200)
     }
 
-    verify(searchService, times(0)).all(
-      any[Option[String]],
-      any[Option[String]],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Sort.Value]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[String],
-      any[Option[String]],
-      any[Option[String]],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Sort.Value]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 
@@ -200,21 +179,7 @@ class AudioControllerTest extends UnitSuite with ScalatraSuite with TestEnvironm
       status should be(200)
     }
 
-    verify(searchService, times(0)).all(
-      any[Option[String]],
-      any[Option[String]],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Sort.Value]
-    )
-    verify(searchService, times(0)).matchingQuery(
-      any[String],
-      any[Option[String]],
-      any[Option[String]],
-      any[Option[Int]],
-      any[Option[Int]],
-      any[Sort.Value]
-    )
+    verify(searchService, times(0)).matchingQuery(any[SearchSettings])
     verify(searchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 }

--- a/src/test/scala/no/ndla/audioapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/SearchServiceTest.scala
@@ -133,7 +133,8 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     license = None,
     page = None,
     pageSize = None,
-    sort = Sort.ByTitleAsc
+    sort = Sort.ByTitleAsc,
+    shouldScroll = false
   )
 
   // Skip tests if no docker environment available
@@ -411,7 +412,8 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     val expectedIds = List(2, 3, 4, 5, 6).sliding(pageSize, pageSize).toList
 
     val Success(initialSearch) =
-      searchService.matchingQuery(searchSettings.copy(pageSize = Some(pageSize), sort = Sort.ByIdAsc))
+      searchService.matchingQuery(
+        searchSettings.copy(pageSize = Some(pageSize), sort = Sort.ByIdAsc, shouldScroll = true))
 
     val Success(scroll1) = searchService.scroll(initialSearch.scrollId.get, "all")
     val Success(scroll2) = searchService.scroll(scroll1.scrollId.get, "all")


### PR DESCRIPTION
Relates to NDLANO/Issues#2226