### PR TITLE
#2434: Fix search-context=initial (++)

### DIFF
--- a/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -151,14 +151,14 @@ trait AudioController {
       */
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           searchService.scroll(scroll, language) match {
             case Success(scrollResult) =>
               val responseHeader = scrollResult.scrollId.map(i => this.scrollId.paramName -> i).toMap
               Ok(searchConverterService.asApiSearchResult(scrollResult), headers = responseHeader)
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
 
     get(

--- a/src/test/scala/no/ndla/audioapi/TestData.scala
+++ b/src/test/scala/no/ndla/audioapi/TestData.scala
@@ -1,0 +1,18 @@
+package no.ndla.audioapi
+
+import no.ndla.audioapi.model.Sort
+import no.ndla.audioapi.model.domain.SearchSettings
+
+object TestData {
+
+  val searchSettings: SearchSettings = SearchSettings(
+    query = None,
+    language = None,
+    license = None,
+    page = None,
+    pageSize = None,
+    sort = Sort.ByTitleAsc,
+    shouldScroll = false,
+    audioType = None
+  )
+}

--- a/src/test/scala/no/ndla/audioapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/SearchServiceTest.scala
@@ -8,19 +8,17 @@
 
 package no.ndla.audioapi.service.search
 
+import no.ndla.audioapi.TestData.searchSettings
 import no.ndla.audioapi.integration.{Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.audioapi.model.Sort
 import no.ndla.audioapi.model.domain._
 import no.ndla.audioapi.{AudioApiProperties, TestEnvironment, UnitSuite}
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.joda.time.{DateTime, DateTimeZone}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatest.Outcome
-import org.testcontainers.elasticsearch.ElasticsearchContainer
 
-import scala.util.{Success, Try}
+import scala.util.Success
 
 class SearchServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -133,17 +131,6 @@ class SearchServiceTest
     updated6,
     Seq.empty,
     AudioType.Podcast
-  )
-
-  val searchSettings: SearchSettings = SearchSettings(
-    query = None,
-    language = None,
-    license = None,
-    page = None,
-    pageSize = None,
-    sort = Sort.ByTitleAsc,
-    shouldScroll = false,
-    audioType = None
   )
 
   // Skip tests if no docker environment available


### PR DESCRIPTION
Relates to NDLANO/Issues#2434

Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting