### PR TITLE
Fix bug where podcastmetas were not updated

### DIFF
--- a/src/main/scala/no/ndla/audioapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ConverterService.scala
@@ -146,7 +146,7 @@ trait ConverterService {
       )
     }
 
-    private def toDomainPodcastMeta(meta: api.NewPodcastMeta, language: String): PodcastMeta = {
+    def toDomainPodcastMeta(meta: api.NewPodcastMeta, language: String): PodcastMeta = {
       domain.PodcastMeta(
         header = meta.header,
         introduction = meta.introduction,


### PR DESCRIPTION
Fikser bug hvor podcastmeta ikke ble oppdatert ved PUT endepunkt.
Kan testes ved å spinne opp audio-api lokalt, og teste å lage/oppdatere podcast meta for en lyd