### PR TITLE
Fix transitive dependecy merge conflict by upgrading scala-uri

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val audio_api = (project in file("."))
       "org.mockito" %% "mockito-scala" % MockitoVersion % "test",
       "org.mockito" %% "mockito-scala-scalatest" % MockitoVersion % "test",
       "org.flywaydb" % "flyway-core" % FlywayVersion,
-      "io.lemonlabs" %% "scala-uri" % "1.5.1",
+      "io.lemonlabs" %% "scala-uri" % "3.2.0",
       "org.jsoup" % "jsoup" % "1.11.3",
       "net.bull.javamelody" % "javamelody-core" % "1.74.0",
       "org.jrobin" % "jrobin" % "1.5.9",

--- a/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
@@ -8,7 +8,6 @@
 
 package no.ndla.audioapi.controller
 
-import io.lemonlabs.uri.dsl._
 import no.ndla.audioapi.AudioApiProperties
 import no.ndla.audioapi.repository.AudioRepository
 import no.ndla.network.ApplicationUrl

--- a/src/main/scala/no/ndla/audioapi/integration/Elastic4sClient.scala
+++ b/src/main/scala/no/ndla/audioapi/integration/Elastic4sClient.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.Executors
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.{Region, Regions}
 import com.sksamuel.elastic4s.http._
-import io.lemonlabs.uri.dsl._
 import no.ndla.audioapi.AudioApiProperties.{RunWithSignedSearchRequests, SearchServer}
 import no.ndla.audioapi.model.domain.NdlaSearchException
 import org.apache.http.client.config.RequestConfig
@@ -25,6 +24,7 @@ import vc.inreach.aws.request.{AWSSigner, AWSSigningRequestInterceptor}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 import scala.util.{Failure, Success, Try}
+import io.lemonlabs.uri.typesafe.dsl._
 
 trait Elastic4sClient {
   val e4sClient: NdlaE4sClient

--- a/src/main/scala/no/ndla/audioapi/integration/MigrationApiClient.scala
+++ b/src/main/scala/no/ndla/audioapi/integration/MigrationApiClient.scala
@@ -8,12 +8,12 @@
 
 package no.ndla.audioapi.integration
 
-import no.ndla.audioapi.AudioApiProperties.{MigrationHost, MigrationPassword, MigrationUser, Environment}
+import io.lemonlabs.uri.typesafe.dsl.pathPartToUrlDsl
+import no.ndla.audioapi.AudioApiProperties.{Environment, MigrationHost, MigrationPassword, MigrationUser}
 import no.ndla.network.NdlaClient
 
 import scala.util.Try
 import scalaj.http.Http
-import io.lemonlabs.uri.dsl._
 
 trait MigrationApiClient {
   this: NdlaClient =>
@@ -21,8 +21,8 @@ trait MigrationApiClient {
 
   class MigrationApiClient {
     val DBSource = "red"
-    val AudioMetadataEndpoint = s"$MigrationHost/audio/:audio_id" ? (s"db-source" -> s"$DBSource")
-    val NodeDataEndpoint = s"$MigrationHost/contents/:node_id" ? (s"db-source" -> s"$DBSource")
+    val AudioMetadataEndpoint = (s"$MigrationHost/audio/:audio_id" ? (s"db-source" -> s"$DBSource")).toString()
+    val NodeDataEndpoint = (s"$MigrationHost/contents/:node_id" ? (s"db-source" -> s"$DBSource")).toString()
 
     def getAudioMetaData(audioNid: String): Try[Seq[MigrationAudioMeta]] = {
       ndlaClient.fetchWithBasicAuth[Seq[MigrationAudioMeta]](Http(AudioMetadataEndpoint.replace(":audio_id", audioNid)),

--- a/src/main/scala/no/ndla/audioapi/service/ImportService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ImportService.scala
@@ -19,9 +19,9 @@ import no.ndla.audioapi.model.{Language, domain}
 import no.ndla.audioapi.repository.AudioRepository
 import no.ndla.audioapi.AudioApiProperties._
 import no.ndla.mapping.License._
+import io.lemonlabs.uri.typesafe.dsl._
 
 import scala.util.Try
-import io.lemonlabs.uri.dsl._
 import no.ndla.mapping.LicenseDefinition
 
 trait ImportService {
@@ -162,8 +162,12 @@ trait ImportService {
     private def uploadAudioFile(audioMeta: MigrationAudioMeta): Try[Audio] = {
       audioStorage
         .getObjectMetaData(audioMeta.fileName)
-        .orElse(audioStorage
-          .storeAudio(audioMeta.url.withScheme("https"), audioMeta.mimeType, audioMeta.fileSize, audioMeta.fileName))
+        .orElse(
+          audioStorage
+            .storeAudio(audioMeta.url.withScheme("https").toString(),
+                        audioMeta.mimeType,
+                        audioMeta.fileSize,
+                        audioMeta.fileName))
         .map(
           s3ObjectMeta =>
             Audio(audioMeta.fileName,


### PR DESCRIPTION
`cats-effect` og `scala-uri` har en dependency versjon konflikt
som gjør at bygging av docker-imaget tryner (simulacrum).

Dette ser ut til å være fikset / versjonene passer i nyere versjon av `scala-uri`.

Kan testes ved å kjøre `./build.sh`