### PR TITLE
#2606: Adds calls to `audioIndexService` for episodes when creating, updating and deleting a series.

### DIFF
--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -570,13 +570,17 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(
       validationService,
       audioRepository,
-      seriesRepository
+      seriesRepository,
+      audioIndexService,
+      seriesIndexService
     )
 
     val series = TestData.SampleSeries
 
     when(seriesRepository.withId(any[Long])).thenReturn(Success(Some(series)))
     when(seriesIndexService.indexDocument(any[domain.Series])).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument(0)))
+    when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument(0)))
     when(audioRepository.withId(any[Long])).thenAnswer((i: InvocationOnMock) => {
       val id = i.getArgument[Long](0)
@@ -604,13 +608,17 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(
       validationService,
       audioRepository,
-      seriesRepository
+      seriesRepository,
+      audioIndexService,
+      seriesIndexService
     )
 
     val series = TestData.SampleSeries
 
     setupSuccessfulSeriesValidation()
     when(seriesIndexService.indexDocument(any[domain.Series])).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument(0)))
+    when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument(0)))
     when(seriesRepository.withId(any[Long])).thenReturn(Success(Some(series)))
     when(audioRepository.withId(any[Long])).thenAnswer((i: InvocationOnMock) => {
@@ -651,7 +659,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(
       validationService,
       audioRepository,
-      seriesRepository
+      seriesRepository,
+      audioIndexService,
+      seriesIndexService
     )
 
     val episodesMap = Map(
@@ -673,6 +683,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(seriesRepository.update(any[domain.Series])(any[DBSession])).thenAnswer((i: InvocationOnMock) => {
       Success(i.getArgument[domain.Series](0))
     })
+    when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenAnswer((i: InvocationOnMock) =>
+      Success(i.getArgument(0)))
 
     val updateSeries = api.NewSeries(
       title = "nyTittel",


### PR DESCRIPTION
Fixes NDLANO/Issues#2606

Kan testes ved å spinne opp lokal audio-api og sjekke at en opprettelse/oppdatering/sletting fører til indeksering av episodene.