### PR TITLE
audio file multiple language versions

### DIFF
--- a/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
+++ b/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
@@ -45,10 +45,11 @@ class V14__CreateMissingFilePaths extends BaseJavaMigration {
                 .extract[List[languageObject]]
                 .map(f => f.language)
                 .distinct
+
               supportedLanguages.map(supportedLang => {
-                val filePath = filePaths.children.find((fp) => {
-                  val lang = fp
-                    .findField((field) => {
+                val existingFilePath = filePaths.children.find(filePath => {
+                  val lang = filePath
+                    .findField(field => {
                       field._1.equals("language")
                     })
                     .get
@@ -58,9 +59,10 @@ class V14__CreateMissingFilePaths extends BaseJavaMigration {
                   lang.s.equals(supportedLang)
 
                 })
-                filePath match {
-                  case Some(file) => {
-                    file
+
+                existingFilePath match {
+                  case Some(filePath) => {
+                    filePath
                   }
                   case None =>
                     val fileObjects = filePaths.extract[List[filePathObject]]
@@ -68,7 +70,6 @@ class V14__CreateMissingFilePaths extends BaseJavaMigration {
                     parse(Serialization.write(newFilePath.copy(language = supportedLang)))
 
                 }
-
               })
             })
           }

--- a/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
+++ b/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
+++ b/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
@@ -43,6 +43,7 @@ class V14__CreateMissingFilePaths extends BaseJavaMigration {
       .find(_.language == language)
       .orElse(sequence.sortBy(lf => languagePriority.reverse.indexOf(lf.language)).lastOption)
   }
+
   val languagePriority = List(
     "nb",
     "nn",
@@ -74,7 +75,6 @@ class V14__CreateMissingFilePaths extends BaseJavaMigration {
     }
     compact(render(newArticle))
   }
-
 
   def update(document: String, id: Long)(implicit session: DBSession): Int = {
     val dataObject = new PGobject()

--- a/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
+++ b/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
@@ -1,0 +1,86 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JArray, JValue}
+import org.json4s.{JNothing, JObject, JString, JValue}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.native.Serialization
+import org.postgresql.util.PGobject
+import scalikejdbc._
+
+class V14__CreateMissingFilePaths extends BaseJavaMigration {
+  implicit val formats = org.json4s.DefaultFormats
+  case class languageObject(language: String)
+  case class filePathObject(filePath: String, fileSize: Long, language: String, mimeType: String)
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      allAudios.map {
+        case (id: Long, document: String) => update(convertDocument(document), id)
+      }
+    }
+  }
+
+  def allAudios(implicit session: DBSession): List[(Long, String)] = {
+    sql"select id, document from audiodata"
+      .map(rs => (rs.long("id"), rs.string("document")))
+      .list()
+      .apply()
+  }
+
+  def convertDocument(document: String): String = {
+
+    val oldArticle = parse(document)
+    val newArticle = oldArticle.mapField {
+      case ("filePaths", filePaths: JArray) =>
+        "filePaths" -> JArray({
+          val supportedLanguages = ((oldArticle \ "tags") ++ (oldArticle \ "titles") ++ (oldArticle \ "filePaths"))
+            .extract[List[languageObject]]
+            .map(f => f.language)
+            .distinct
+          supportedLanguages.map(supportedLang => {
+            val filePath = filePaths.children.find((fp) => {
+              val lang = fp
+                .findField((field) => {
+                  field._1.equals("language")
+                })
+                .get
+                ._2
+                .asInstanceOf[JString]
+
+              lang.s.equals(supportedLang)
+
+            })
+            filePath match {
+              case Some(file) => {
+                file
+              }
+              case None =>
+                val fileObjects = filePaths.extract[List[filePathObject]]
+                val newFilePath = fileObjects.find(fp => fp.language.equals("nb")).getOrElse(fileObjects.head)
+                parse(Serialization.write(newFilePath.copy(language = supportedLang)))
+
+            }
+
+          })
+        })
+
+      case x => x
+
+    }
+
+    compact(render(newArticle))
+  }
+
+  def update(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update audiodata set document = ${dataObject} where id = $id".update().apply()
+  }
+
+}

--- a/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
@@ -24,6 +24,5 @@ case class UpdatedAudioMetaInformation(
   @(ApiModelProperty @field)(description = "Meta information about podcast, only applicable if audioType is 'podcast'.") podcastMeta: Option[NewPodcastMeta],
   @(ApiModelProperty @field)(description = "Id of series if the audio is a podcast and a part of a series.") seriesId: Option[Long],
   @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String],
-  @(ApiModelProperty @field)(description = "The audio file for this language") audioFile: Option[Audio],
 )
 // format: on

--- a/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
@@ -23,6 +23,7 @@ case class UpdatedAudioMetaInformation(
   @(ApiModelProperty @field)(description = "Type of audio. 'standard', or 'podcast', defaults to 'standard'") audioType: Option[String],
   @(ApiModelProperty @field)(description = "Meta information about podcast, only applicable if audioType is 'podcast'.") podcastMeta: Option[NewPodcastMeta],
   @(ApiModelProperty @field)(description = "Id of series if the audio is a podcast and a part of a series.") seriesId: Option[Long],
-  @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String]
+  @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String],
+    @(ApiModelProperty @field)(description = "The audio file for this language") audioFile: Option[Audio],
 )
 // format: on

--- a/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
@@ -24,6 +24,6 @@ case class UpdatedAudioMetaInformation(
   @(ApiModelProperty @field)(description = "Meta information about podcast, only applicable if audioType is 'podcast'.") podcastMeta: Option[NewPodcastMeta],
   @(ApiModelProperty @field)(description = "Id of series if the audio is a podcast and a part of a series.") seriesId: Option[Long],
   @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String],
-    @(ApiModelProperty @field)(description = "The audio file for this language") audioFile: Option[Audio],
+  @(ApiModelProperty @field)(description = "The audio file for this language") audioFile: Option[Audio],
 )
 // format: on

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -307,15 +307,13 @@ trait WriteService {
         savedAudio: Option[Audio]): Try[(domain.AudioMetaInformation, Option[Audio])] = {
       val mergedFilePaths = savedAudio match {
         case None =>
-          toUpdate.audioFile match {
+          val existingFilePath = existing.filePaths.find(audio => audio.language == toUpdate.language)
+          existingFilePath match {
             case Some(audio) =>
               // Only copy the metadata to new language if filepath already exist in Audio.
               if (!audio.language.equals(toUpdate.language) && existing.filePaths.exists(p =>
-                    p.filePath.equals(audio.url))) {
-                existing.filePaths :+ Audio(language = toUpdate.language,
-                                            filePath = audio.url,
-                                            mimeType = audio.mimeType,
-                                            fileSize = audio.fileSize)
+                    p.filePath.equals(audio.filePath))) {
+                existing.filePaths :+ audio.copy(language = toUpdate.language)
               } else {
                 existing.filePaths
 

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -311,7 +311,7 @@ trait WriteService {
           existingFilePath match {
             case Some(audio) =>
               // Only copy the metadata to new language if filepath already exist in Audio.
-              if (!audio.language.equals(toUpdate.language) && existing.filePaths.exists(p =>
+              if (audio.language != toUpdate.language && existing.filePaths.exists(p =>
                     p.filePath.equals(audio.filePath))) {
                 existing.filePaths :+ audio.copy(language = toUpdate.language)
               } else {

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -260,10 +260,8 @@ trait WriteService {
               }
           }
 
-
           val savedAudio = metadataAndFile.map(_._2)
           val metadataToSave = metadataAndFile.map(_._1)
-
 
           val finished =
             metadataToSave.flatMap(
@@ -273,11 +271,9 @@ trait WriteService {
                                         Some(metadataToUpdate.language),
                                         metadataToUpdate.seriesId))
 
-
           if (finished.isFailure && !savedAudio.isFailure) {
             savedAudio.get.foreach(deleteFile)
           }
-
 
           finished
       }
@@ -314,8 +310,12 @@ trait WriteService {
           toUpdate.audioFile match {
             case Some(audio) =>
               // Only copy the metadata to new language if filepath already exist in Audio.
-              if (!audio.language.equals(toUpdate.language) && existing.filePaths.exists(p => p.filePath.equals(audio.url))) {
-                existing.filePaths :+ Audio(language = toUpdate.language, filePath = audio.url, mimeType = audio.mimeType, fileSize = audio.fileSize)
+              if (!audio.language.equals(toUpdate.language) && existing.filePaths.exists(p =>
+                    p.filePath.equals(audio.url))) {
+                existing.filePaths :+ Audio(language = toUpdate.language,
+                                            filePath = audio.url,
+                                            mimeType = audio.mimeType,
+                                            fileSize = audio.fileSize)
               } else {
                 existing.filePaths
 

--- a/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
+++ b/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
@@ -37,8 +37,18 @@ class V14__CreateMissingFilePathsTest extends UnitSuite with TestEnvironment {
       val expected =
         s"""{"tags":[{"tags":["abc"],"language":"en"},{"tags":["abc"],"language":"nb"},{"tags":["abc"],"language":"unknown"},{"tags":["abc"],"language":"nn"}],"titles":[{"title":"123","language":"unknown"},{"title":"123","language":"nb"},{"title":"123","language":"nn"},{"title":"123","language":"en"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":1000,"language":"en","mimeType":"audio/mpeg"},{"filePath":"file2.mp3","fileSize":2000,"language":"nb","mimeType":"audio/mpeg"},{"filePath":"file3.mp3","fileSize":3000,"language":"unknown","mimeType":"audio/mpeg"},{"filePath":"file2.mp3","fileSize":2000,"language":"nn","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
 
-      println(migration.convertDocument(old))
-      println(expected)
+      migration.convertDocument(old) should equal(expected)
+    }
+  }
+
+  test("migration should handle non-existing audioFiles list") {
+    {
+      val old =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      val expected =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"updatedBy":"swagger-client","supportedLanguages":null}"""
+
       migration.convertDocument(old) should equal(expected)
     }
   }

--- a/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
+++ b/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
@@ -1,0 +1,19 @@
+package db.migration
+
+import no.ndla.audioapi.{TestEnvironment, UnitSuite}
+
+class V14__CreateMissingFilePathsTest extends UnitSuite with TestEnvironment {
+  val migration = new V14__CreateMissingFilePaths
+
+  test("migration should audioFiles for missing languages") {
+    {
+      val old =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"unknown","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      val expected =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"unknown","mimeType":"audio/mpeg"},{"filePath":"file1.mp3","fileSize":6326273,"language":"nb","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      migration.convertDocument(old) should equal(expected)
+    }
+  }
+}

--- a/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
+++ b/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
@@ -5,7 +5,7 @@ import no.ndla.audioapi.{TestEnvironment, UnitSuite}
 class V14__CreateMissingFilePathsTest extends UnitSuite with TestEnvironment {
   val migration = new V14__CreateMissingFilePaths
 
-  test("migration should audioFiles for missing languages") {
+  test("migration should create audioFiles for missing languages") {
     {
       val old =
         s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"unknown","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
@@ -13,6 +13,32 @@ class V14__CreateMissingFilePathsTest extends UnitSuite with TestEnvironment {
       val expected =
         s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"unknown","mimeType":"audio/mpeg"},{"filePath":"file1.mp3","fileSize":6326273,"language":"nb","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
 
+      migration.convertDocument(old) should equal(expected)
+    }
+  }
+
+  test("migration should not create any audioFiles if list is empty") {
+    {
+      val old =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      val expected =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      migration.convertDocument(old) should equal(expected)
+    }
+  }
+
+  test("migration should use nb as fallback if it exists") {
+    {
+      val old =
+        s"""{"tags":[{"tags":["abc"],"language":"en"},{"tags":["abc"],"language":"nb"},{"tags":["abc"],"language":"unknown"},{"tags":["abc"],"language":"nn"}],"titles":[{"title":"123","language":"unknown"},{"title":"123","language":"nb"},{"title":"123","language":"nn"},{"title":"123","language":"en"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":1000,"language":"en","mimeType":"audio/mpeg"},{"filePath":"file2.mp3","fileSize":2000,"language":"nb","mimeType":"audio/mpeg"},{"filePath":"file3.mp3","fileSize":3000,"language":"unknown","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      val expected =
+        s"""{"tags":[{"tags":["abc"],"language":"en"},{"tags":["abc"],"language":"nb"},{"tags":["abc"],"language":"unknown"},{"tags":["abc"],"language":"nn"}],"titles":[{"title":"123","language":"unknown"},{"title":"123","language":"nb"},{"title":"123","language":"nn"},{"title":"123","language":"en"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":1000,"language":"en","mimeType":"audio/mpeg"},{"filePath":"file2.mp3","fileSize":2000,"language":"nb","mimeType":"audio/mpeg"},{"filePath":"file3.mp3","fileSize":3000,"language":"unknown","mimeType":"audio/mpeg"},{"filePath":"file2.mp3","fileSize":2000,"language":"nn","mimeType":"audio/mpeg"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      println(migration.convertDocument(old))
+      println(expected)
       migration.convertDocument(old) should equal(expected)
     }
   }

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -45,7 +45,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     podcastMeta = None,
     manuscript = None,
     seriesId = None,
-    audioFile = None,
   )
 
   val updated: Date = new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC).toDate
@@ -270,7 +269,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                                                None,
                                                None,
                                                None,
-                                               None,
                                                None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(1)
@@ -285,7 +283,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                                                "nb",
                                                converterService.toApiCopyright(domainAudioMeta.copyright),
                                                Seq(),
-                                               None,
                                                None,
                                                None,
                                                None,
@@ -304,7 +301,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                                                "en",
                                                converterService.toApiCopyright(domainAudioMeta.copyright),
                                                Seq(),
-                                               None,
                                                None,
                                                None,
                                                None,
@@ -328,7 +324,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                                                None,
                                                None,
                                                None,
-                                               None,
                                                None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, Some(newAudio)).get
     merged.titles.length should be(1)
@@ -348,7 +343,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                                                "nb",
                                                converterService.toApiCopyright(domainAudioMeta.copyright),
                                                Seq(),
-                                               None,
                                                None,
                                                None,
                                                None,
@@ -784,7 +778,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
   test("Updating with file from another language will create a copy of the filePath") {
     val updatedAudio = api.Audio("file1.mp3", "audio/mpeg", 1024, "nb")
-    val updatedMeta = updatedAudioMeta.copy(language = "sma", audioFile = Some(updatedAudio))
+    val updatedMeta = updatedAudioMeta.copy(language = "sma")
     val afterInsert = multiLangAudio.copy(
       titles = multiLangAudio.titles :+ domain.Title("title", "sma"),
       filePaths = multiLangAudio.filePaths :+ domain.Audio("file1.mp3", "audio/mpeg", 1024, "sma"),
@@ -810,7 +804,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
   test("Updating with file that does not exist in other language will not make a copy") {
     val updatedAudio = api.Audio("file0.mp3", "audio/mpeg", 1024, "nb")
-    val updatedMeta = updatedAudioMeta.copy(language = "sma", audioFile = Some(updatedAudio))
+    val updatedMeta = updatedAudioMeta.copy(language = "sma")
     val afterInsert = multiLangAudio.copy(
       titles = multiLangAudio.titles :+ domain.Title("title", "sma"),
       filePaths = multiLangAudio.filePaths,

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -58,20 +58,20 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   val updated1: Date = new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC).toDate
 
   val publicDomain: domain.Copyright = domain.Copyright("publicdomain",
-    Some("Metropolis"),
-    List(domain.Author("Forfatter", "Bruce Wayne")),
-    Seq(),
-    Seq(),
-    None,
-    None,
-    None)
+                                                        Some("Metropolis"),
+                                                        List(domain.Author("Forfatter", "Bruce Wayne")),
+                                                        Seq(),
+                                                        Seq(),
+                                                        None,
+                                                        None,
+                                                        None)
 
   val multiLangAudio: domain.AudioMetaInformation = domain.AudioMetaInformation(
     Some(4),
     Some(1),
     List(domain.Title("Donald Duck kjører bil", "nb"),
-      domain.Title("Donald Duck kjører bil", "nn"),
-      domain.Title("Donald Duck drives a car", "en")),
+         domain.Title("Donald Duck kjører bil", "nn"),
+         domain.Title("Donald Duck drives a car", "en")),
     List(
       domain.Audio("file1.mp3", "audio/mpeg", 1024, "nb"),
       domain.Audio("file2.mp3", "audio/mpeg", 1024, "nn"),
@@ -192,8 +192,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Failure(new ValidationException(errors = Seq())))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -208,8 +208,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -224,8 +224,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -241,8 +241,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -263,15 +263,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-      "A new english title",
-      "en",
-      converterService.toApiCopyright(domainAudioMeta.copyright),
-      Seq(),
-      None,
-      None,
-      None,
-      None,
-      None)
+                                               "A new english title",
+                                               "en",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq(),
+                                               None,
+                                               None,
+                                               None,
+                                               None,
+                                               None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -281,15 +281,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-      "En ny norsk tittel",
-      "nb",
-      converterService.toApiCopyright(domainAudioMeta.copyright),
-      Seq(),
-      None,
-      None,
-      None,
-      None,
-      None)
+                                               "En ny norsk tittel",
+                                               "nb",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq(),
+                                               None,
+                                               None,
+                                               None,
+                                               None,
+                                               None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(2)
     merged.titles.filter(_.language.contains("nb")).head.title should equal("En ny norsk tittel")
@@ -300,15 +300,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-      "A new english title",
-      "en",
-      converterService.toApiCopyright(domainAudioMeta.copyright),
-      Seq(),
-      None,
-      None,
-      None,
-      None,
-      None)
+                                               "A new english title",
+                                               "en",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq(),
+                                               None,
+                                               None,
+                                               None,
+                                               None,
+                                               None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -321,15 +321,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val newAudio = Audio(newFileName2, "audio/mp3", 1024, "en")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-      "A new english title",
-      "en",
-      converterService.toApiCopyright(domainAudioMeta.copyright),
-      Seq(),
-      None,
-      None,
-      None,
-      None,
-      None)
+                                               "A new english title",
+                                               "en",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq(),
+                                               None,
+                                               None,
+                                               None,
+                                               None,
+                                               None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, Some(newAudio)).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -344,15 +344,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val newAudio = Audio(newFileName2, "audio/mp3", 1024, "nb")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-      "En ny norsk tittel",
-      "nb",
-      converterService.toApiCopyright(domainAudioMeta.copyright),
-      Seq(),
-      None,
-      None,
-      None,
-      None,
-      None)
+                                               "En ny norsk tittel",
+                                               "nb",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq(),
+                                               None,
+                                               None,
+                                               None,
+                                               None,
+                                               None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, Some(newAudio)).get
     merged.titles.length should be(2)
     merged.filePaths.length should be(2)
@@ -398,8 +398,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Failure(new ValidationException(errors = Seq())))
 
     val result = writeService.updateAudio(1, updatedAudioMeta, Some(fileMock1))
@@ -416,8 +416,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long]))
       .thenThrow(new RuntimeException("Something happened"))
@@ -438,8 +438,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
@@ -516,8 +516,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
@@ -561,7 +561,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   def setupSuccessfulSeriesValidation(): Unit = {
     when(
       validationService.validatePodcastEpisodes(any[Seq[(Long, Option[domain.AudioMetaInformation])]],
-        any[Option[Long]])).thenAnswer((i: InvocationOnMock) => {
+                                                any[Option[Long]])).thenAnswer((i: InvocationOnMock) => {
       val inputArgument = i.getArgument[Seq[(Long, Option[domain.AudioMetaInformation])]](0)
       val passedEpisodes = inputArgument.map(_._2.get)
       Success(passedEpisodes)
@@ -794,8 +794,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(audioRepository.withId(4)).thenReturn(Some(multiLangAudio))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(afterInsert))
     when(audioRepository.setSeriesId(any, any)(any)).thenReturn(Success(4))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
@@ -820,8 +820,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(audioRepository.withId(4)).thenReturn(Some(multiLangAudio))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(afterInsert))
     when(audioRepository.setSeriesId(any, any)(any)).thenReturn(Success(4))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
@@ -830,8 +830,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     val result = writeService.updateAudio(4, updatedMeta, None)
     result.isSuccess should be(true)
-    result.get.audioFile.language should not equal("sma")
-    result.get.audioFile.url should not include("file0.mp3")
+    result.get.audioFile.language should not equal ("sma")
+    result.get.audioFile.url should not include ("file0.mp3")
   }
 
   test("Delete language version will not delete file if it exist in another language") {

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -44,7 +44,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     audioType = None,
     podcastMeta = None,
     manuscript = None,
-    seriesId = None
+    seriesId = None,
+    audioFile = None,
   )
 
   val updated: Date = new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC).toDate
@@ -57,20 +58,20 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   val updated1: Date = new DateTime(2017, 4, 1, 12, 15, 32, DateTimeZone.UTC).toDate
 
   val publicDomain: domain.Copyright = domain.Copyright("publicdomain",
-                                                        Some("Metropolis"),
-                                                        List(domain.Author("Forfatter", "Bruce Wayne")),
-                                                        Seq(),
-                                                        Seq(),
-                                                        None,
-                                                        None,
-                                                        None)
+    Some("Metropolis"),
+    List(domain.Author("Forfatter", "Bruce Wayne")),
+    Seq(),
+    Seq(),
+    None,
+    None,
+    None)
 
   val multiLangAudio: domain.AudioMetaInformation = domain.AudioMetaInformation(
     Some(4),
     Some(1),
     List(domain.Title("Donald Duck kjører bil", "nb"),
-         domain.Title("Donald Duck kjører bil", "nn"),
-         domain.Title("Donald Duck drives a car", "en")),
+      domain.Title("Donald Duck kjører bil", "nn"),
+      domain.Title("Donald Duck drives a car", "en")),
     List(
       domain.Audio("file1.mp3", "audio/mpeg", 1024, "nb"),
       domain.Audio("file2.mp3", "audio/mpeg", 1024, "nn"),
@@ -191,8 +192,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Failure(new ValidationException(errors = Seq())))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -207,8 +208,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -223,8 +224,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -240,8 +241,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
       .thenReturn(Success(mock[ObjectMetadata](withSettings.lenient())))
@@ -262,14 +263,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-                                               "A new english title",
-                                               "en",
-                                               converterService.toApiCopyright(domainAudioMeta.copyright),
-                                               Seq(),
-                                               None,
-                                               None,
-                                               None,
-                                               None)
+      "A new english title",
+      "en",
+      converterService.toApiCopyright(domainAudioMeta.copyright),
+      Seq(),
+      None,
+      None,
+      None,
+      None,
+      None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -279,14 +281,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-                                               "En ny norsk tittel",
-                                               "nb",
-                                               converterService.toApiCopyright(domainAudioMeta.copyright),
-                                               Seq(),
-                                               None,
-                                               None,
-                                               None,
-                                               None)
+      "En ny norsk tittel",
+      "nb",
+      converterService.toApiCopyright(domainAudioMeta.copyright),
+      Seq(),
+      None,
+      None,
+      None,
+      None,
+      None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(2)
     merged.titles.filter(_.language.contains("nb")).head.title should equal("En ny norsk tittel")
@@ -297,14 +300,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(authUser.userOrClientid()).thenReturn("ndla54321")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-                                               "A new english title",
-                                               "en",
-                                               converterService.toApiCopyright(domainAudioMeta.copyright),
-                                               Seq(),
-                                               None,
-                                               None,
-                                               None,
-                                               None)
+      "A new english title",
+      "en",
+      converterService.toApiCopyright(domainAudioMeta.copyright),
+      Seq(),
+      None,
+      None,
+      None,
+      None,
+      None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -317,14 +321,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val newAudio = Audio(newFileName2, "audio/mp3", 1024, "en")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-                                               "A new english title",
-                                               "en",
-                                               converterService.toApiCopyright(domainAudioMeta.copyright),
-                                               Seq(),
-                                               None,
-                                               None,
-                                               None,
-                                               None)
+      "A new english title",
+      "en",
+      converterService.toApiCopyright(domainAudioMeta.copyright),
+      Seq(),
+      None,
+      None,
+      None,
+      None,
+      None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, Some(newAudio)).get
     merged.titles.length should be(1)
     merged.titles.head.title should equal("A new english title")
@@ -339,14 +344,15 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val newAudio = Audio(newFileName2, "audio/mp3", 1024, "nb")
 
     val toUpdate = UpdatedAudioMetaInformation(1,
-                                               "En ny norsk tittel",
-                                               "nb",
-                                               converterService.toApiCopyright(domainAudioMeta.copyright),
-                                               Seq(),
-                                               None,
-                                               None,
-                                               None,
-                                               None)
+      "En ny norsk tittel",
+      "nb",
+      converterService.toApiCopyright(domainAudioMeta.copyright),
+      Seq(),
+      None,
+      None,
+      None,
+      None,
+      None)
     val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, Some(newAudio)).get
     merged.titles.length should be(2)
     merged.filePaths.length should be(2)
@@ -392,8 +398,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Failure(new ValidationException(errors = Seq())))
 
     val result = writeService.updateAudio(1, updatedAudioMeta, Some(fileMock1))
@@ -410,8 +416,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long]))
       .thenThrow(new RuntimeException("Something happened"))
@@ -432,8 +438,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenReturn(Success(domainAudioMeta))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
@@ -510,8 +516,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-                                 any[Option[domain.AudioMetaInformation]],
-                                 any[Option[domain.Series]]))
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
@@ -521,7 +527,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     verify(audioRepository, times(1)).update(expectedAudio, audioId)
   }
 
-  test("That deleting last language version deletes entire image") {
+  test("That deleting last language version deletes entire audio") {
     reset(audioRepository)
     reset(audioStorage)
     reset(audioIndexService)
@@ -555,7 +561,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   def setupSuccessfulSeriesValidation(): Unit = {
     when(
       validationService.validatePodcastEpisodes(any[Seq[(Long, Option[domain.AudioMetaInformation])]],
-                                                any[Option[Long]])).thenAnswer((i: InvocationOnMock) => {
+        any[Option[Long]])).thenAnswer((i: InvocationOnMock) => {
       val inputArgument = i.getArgument[Seq[(Long, Option[domain.AudioMetaInformation])]](0)
       val passedEpisodes = inputArgument.map(_._2.get)
       Success(passedEpisodes)
@@ -774,6 +780,39 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result.isSuccess should be(true)
 
     verify(audioRepository, times(0)).setSeriesId(any[Long], any[Option[Long]])(any[DBSession])
+  }
+
+  test("That file is deleted on update if no longer in use") {
+    reset(
+      validationService,
+      audioRepository,
+      seriesRepository
+    )
+    val newApiFile = api.Audio("file2.mp3", "audio/mpeg", 1024, "en")
+    val newDomainFile = domain.Audio("file2.mp3", "audio/mpeg", 1024, "en")
+    val afterInsert = multiLangAudio.copy(filePaths = multiLangAudio.filePaths.slice(0, 2) ++ List(newDomainFile))
+
+    when(audioRepository.withId(4)).thenReturn(Some(multiLangAudio))
+    when(validationService.validateAudioFile(any[FileItem])).thenReturn(None)
+    when(audioStorage.storeAudio(any[InputStream], any[String], any[Long], any[String]))
+      .thenReturn(Success(s3ObjectMock))
+    when(
+      validationService.validate(any[domain.AudioMetaInformation],
+        any[Option[domain.AudioMetaInformation]],
+        any[Option[domain.Series]]))
+      .thenReturn(Success(multiLangAudio))
+    when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
+    when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
+    when(tagIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
+    when(audioRepository.setSeriesId(any, any)(any)).thenReturn(Success(1))
+
+    val toUpdate = updatedAudioMeta.copy(audioFile = Some(newApiFile))
+
+    val result = writeService.updateAudio(4, toUpdate, None)
+    result.isSuccess should be (true)
+
+    verify(audioStorage, times(1)).deleteObject((any[String]))
+
   }
 
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2691

Hva som er gjort i denne PRen:
Ved lagring av språkversjon av Audio der lydfil ikke finnes, skal metadata fra fallback-språk kopieres. Det er også skrevet en migrasjon som kopierer metadata for språkversjoner der lydfil ikke finnes.

Problemet som er løst:
Det finnes Audio med flere språkversjoner, men selve lydfilen finnes kun for ett språk. De andre språkversjonene viser denne lydfilen som fallback i ed. Ved sletting av det aktuelle språket vil ikke lenger de resterende språkene ha en fallback. 