### PR TITLE
Clone file when updating audio with file from another language

### DIFF
--- a/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
@@ -23,6 +23,7 @@ case class UpdatedAudioMetaInformation(
   @(ApiModelProperty @field)(description = "Type of audio. 'standard', or 'podcast', defaults to 'standard'") audioType: Option[String],
   @(ApiModelProperty @field)(description = "Meta information about podcast, only applicable if audioType is 'podcast'.") podcastMeta: Option[NewPodcastMeta],
   @(ApiModelProperty @field)(description = "Id of series if the audio is a podcast and a part of a series.") seriesId: Option[Long],
-  @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String]
+  @(ApiModelProperty @field)(description = "Manuscript for the audio") manuscript: Option[String],
+  @(ApiModelProperty @field)(description = "Audio file meta information") audioFile: Option[Audio],
 )
 // format: on

--- a/src/main/scala/no/ndla/audioapi/service/AudioStorageService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/AudioStorageService.scala
@@ -9,9 +9,9 @@
 package no.ndla.audioapi.service
 
 import java.io.InputStream
-
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import com.amazonaws.services.s3.model.{CopyObjectRequest, ObjectMetadata, PutObjectRequest}
 import no.ndla.audioapi.AudioApiProperties.StorageName
+import no.ndla.audioapi.ComponentRegistry.writeService.randomFileName
 import no.ndla.audioapi.integration.AmazonClient
 
 import scala.util.{Failure, Success, Try}
@@ -44,5 +44,13 @@ trait AudioStorageService {
 
     def deleteObject(storageKey: String): Try[Unit] = Try(amazonClient.deleteObject(StorageName, storageKey))
 
+    def cloneObject(storageKey: String, destinationKey: String): Try[ObjectMetadata] = {
+      val request = new CopyObjectRequest(StorageName, storageKey, StorageName, destinationKey)
+
+      Try(amazonClient.copyObject(request)) match {
+        case Success(_)         => getObjectMetaData(destinationKey)
+        case Failure(exception) => Failure(exception)
+      }
+    }
   }
 }

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -808,7 +808,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
     when(tagIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
-    when(audioStorage.cloneObject(any[String],any[String])).thenReturn(Success(s3ObjectMock))
+    when(audioStorage.cloneObject(any[String], any[String])).thenReturn(Success(s3ObjectMock))
 
     val result = writeService.updateAudio(4, updatedMeta, None)
     result.isSuccess should be(true)


### PR DESCRIPTION
Fixes NDLANO/Issues#2691

Når man oppretter en ny språkversjon i ed vil lydfilen som vises være fallback:
- Eksisterende språk er "unknown"
- Oppretter språk "bokmål"
- Lagrer "bokmål" => audioFile som sendes til backend er da fallback, altså `language: unknown`
- Dersom man sletter "unknown" språkversjon etterpå slettes også filen og "bokmål" har ikke lenger en lydfil tilknyttet seg.

Løsningen:
- Dersom man i tilfellet opprettet "bokmål" og sender med en audioFile med annet språk, så vil filen i s3 klones og det opprettes en audioFile med språk "bokmål".

