### PR TITLE
Remove duplicates from tags in updated metadata

### DIFF
--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -330,7 +330,8 @@ trait WriteService {
             revision = Some(toUpdate.revision),
             titles =
               converterService.mergeLanguageField(existing.titles, domain.Title(toUpdate.title, toUpdate.language)),
-            tags = converterService.mergeLanguageField(existing.tags, domain.Tag(toUpdate.tags, toUpdate.language)),
+            tags =
+              converterService.mergeLanguageField(existing.tags, domain.Tag(toUpdate.tags.distinct, toUpdate.language)),
             filePaths = mergedFilePaths,
             copyright = converterService.toDomainCopyright(toUpdate.copyright),
             updated = clock.now(),

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -776,4 +776,21 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     verify(audioRepository, times(0)).setSeriesId(any[Long], any[Option[Long]])(any[DBSession])
   }
 
+  test("that mergeAudioMeta removes duplicate tags from toUpdate for given language") {
+    when(authUser.userOrClientid()).thenReturn("ndla54321")
+
+    val toUpdate = UpdatedAudioMetaInformation(1,
+                                               "A new english title",
+                                               "en",
+                                               converterService.toApiCopyright(domainAudioMeta.copyright),
+                                               Seq("abc", "123", "abc", "def"),
+                                               None,
+                                               None,
+                                               None,
+                                               None)
+    val (merged, _) = writeService.mergeAudioMeta(domainAudioMeta, toUpdate, None).get
+    merged.tags.length should be(1)
+    merged.tags.head.tags should equal(Seq("abc", "123", "def"))
+  }
+
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2694

Fjerner duplikate strenger fra innsendte tags