### PR TITLE
#2739: Handle unsupported languages in search

### DIFF
--- a/src/main/scala/no/ndla/audioapi/model/Language.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Language.scala
@@ -28,6 +28,7 @@ object Language {
     LanguageAnalyzer("de", GermanLanguageAnalyzer),
     LanguageAnalyzer("es", SpanishLanguageAnalyzer),
     LanguageAnalyzer("se", StandardAnalyzer), // SAMI
+    LanguageAnalyzer("sma", StandardAnalyzer), // SAMI
     LanguageAnalyzer("zh", ChineseLanguageAnalyzer),
     LanguageAnalyzer(UnknownLanguage, StandardAnalyzer)
   )

--- a/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
@@ -67,18 +67,6 @@ trait AudioSearchService {
       executeSearch(settings, fullSearch)
     }
 
-    private def languageSpecificSearch(searchField: String,
-                                       language: Option[String],
-                                       query: String,
-                                       boost: Float): Query = {
-      language match {
-        case None | Some(Language.AllLanguages) | Some("*") =>
-          simpleStringQuery(query).field(s"$searchField.*", boost)
-        case Some(lang) =>
-          simpleStringQuery(query).field(s"$searchField.$lang", boost)
-      }
-    }
-
     def executeSearch(settings: SearchSettings, queryBuilder: BoolQuery): Try[domain.SearchResult[api.AudioSummary]] = {
 
       val licenseFilter = settings.license match {
@@ -93,8 +81,8 @@ trait AudioSearchService {
       }
 
       val (languageFilter, searchLanguage) = settings.language match {
-        case None | Some(Language.AllLanguages) => (None, "*")
-        case Some(lang)                         => (Some(existsQuery(s"titles.$lang")), lang)
+        case Some(lang) if Language.supportedLanguages.contains(lang) => (Some(existsQuery(s"titles.$lang")), lang)
+        case _                                                        => (None, "*")
       }
 
       val audioTypeFilter = settings.audioType match {

--- a/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
@@ -247,17 +247,15 @@ trait IndexService {
       */
     protected def generateLanguageSupportedFieldList(fieldName: String,
                                                      keepRaw: Boolean = false): Seq[FieldDefinition] = {
-      keepRaw match {
-        case true =>
-          languageAnalyzers.map(
-            langAnalyzer =>
-              textField(s"$fieldName.${langAnalyzer.lang}")
-                .fielddata(false)
-                .analyzer(langAnalyzer.analyzer)
-                .fields(keywordField("raw")))
-        case false =>
-          languageAnalyzers.map(langAnalyzer =>
-            textField(s"$fieldName.${langAnalyzer.lang}").fielddata(false).analyzer(langAnalyzer.analyzer))
+      if (keepRaw) {
+        languageAnalyzers.map(
+          langAnalyzer =>
+            textField(s"$fieldName.${langAnalyzer.lang}")
+              .analyzer(langAnalyzer.analyzer)
+              .fields(keywordField("raw")))
+      } else {
+        languageAnalyzers.map(langAnalyzer =>
+          textField(s"$fieldName.${langAnalyzer.lang}").analyzer(langAnalyzer.analyzer))
       }
     }
 

--- a/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
@@ -64,18 +64,6 @@ trait SeriesSearchService {
       executeSearch(settings, fullSearch)
     }
 
-    private def languageSpecificSearch(searchField: String,
-                                       language: Option[String],
-                                       query: String,
-                                       boost: Float): Query = {
-      language match {
-        case None | Some(Language.AllLanguages) | Some("*") =>
-          simpleStringQuery(query).field(s"$searchField.*", boost)
-        case Some(lang) =>
-          simpleStringQuery(query).field(s"$searchField.$lang", boost)
-      }
-    }
-
     def executeSearch(settings: SeriesSearchSettings,
                       queryBuilder: BoolQuery): Try[domain.SearchResult[api.SeriesSummary]] = {
 

--- a/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
@@ -43,15 +43,11 @@ trait TagSearchService {
       Try(read[SearchableTag](hit)).map(_.tag)
     }
 
-    def all(
-        language: String,
-        page: Int,
-        pageSize: Int
-    ): Try[SearchResult[String]] = executeSearch(language, page, pageSize, boolQuery())
-
     def matchingQuery(query: String, searchLanguage: String, page: Int, pageSize: Int): Try[SearchResult[String]] = {
-
-      val language = if (searchLanguage == Language.AllLanguages) "*" else searchLanguage
+      val language = searchLanguage match {
+        case lang if Language.supportedLanguages.contains(lang) => lang
+        case _                                                  => "*"
+      }
 
       val fullQuery = boolQuery()
         .must(


### PR DESCRIPTION
NDLANO/Issues#2739

Kan testes ved å søke på tom-query mot et språk som ikke er støttet (Og teste at `sma` er støttet).