### PR TITLE
2724 delete file on delete language

### DIFF
--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -134,10 +134,12 @@ trait WriteService {
           else {
             val removedFilePath = existing.filePaths.find(audio => audio.language == language).get
             // If last audio with this filePath, delete the file.
-            if (!newAudio.filePaths.exists(audio => audio.filePath == removedFilePath.filePath)) {
+            val deleteResult = if (!newAudio.filePaths.exists(audio => audio.filePath == removedFilePath.filePath)) {
               deleteFile(removedFilePath)
-            }
-            validateAndUpdateMetaData(audioId, newAudio, existing, None, None).map(Some(_))
+            } else Success(())
+
+            deleteResult.flatMap(_ => validateAndUpdateMetaData(audioId, newAudio, existing, None, None).map(Some(_)))
+
           }
 
         case Some(_) =>

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -279,6 +279,17 @@ trait WriteService {
 
           if (finished.isFailure && !savedAudio.isFailure) {
             savedAudio.get.foreach(deleteFile)
+          } else {
+            // If old file in update language version is no longer in use, delete it
+            val oldAudio = existingMetadata.filePaths.find(audio => audio.language == metadataToUpdate.language)
+            oldAudio match {
+              case None =>
+              case Some(old) =>
+                if (!existingMetadata.filePaths.exists(audio => audio.language != old.language && audio.filePath == old.filePath)) {
+                  deleteFile(old)
+                }
+            }
+
           }
 
           finished
@@ -323,6 +334,7 @@ trait WriteService {
           converterService.mergeLanguageField(
             existing.filePaths,
             domain.Audio(audio.filePath, audio.mimeType, audio.fileSize, audio.language))
+
       }
 
       val newPodcastMeta =

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -131,8 +131,14 @@ trait WriteService {
           // If last language version delete entire audio
           if (newAudio.supportedLanguages.isEmpty)
             deleteAudioAndFiles(audioId).map(_ => None)
-          else
+          else {
+            val removedFilePath = existing.filePaths.find(audio => audio.language == language).get
+            // If last audio with this filePath, delete the file.
+            if (!newAudio.filePaths.exists(audio => audio.filePath == removedFilePath.filePath)) {
+              deleteFile(removedFilePath)
+            }
             validateAndUpdateMetaData(audioId, newAudio, existing, None, None).map(Some(_))
+          }
 
         case Some(_) =>
           Failure(new NotFoundException(s"Audio with id $audioId does not exist in language '$language'."))

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -285,7 +285,8 @@ trait WriteService {
             oldAudio match {
               case None =>
               case Some(old) =>
-                if (!existingMetadata.filePaths.exists(audio => audio.language != old.language && audio.filePath == old.filePath)) {
+                if (!existingMetadata.filePaths.exists(
+                      audio => audio.language != old.language && audio.filePath == old.filePath)) {
                   deleteFile(old)
                 }
             }

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -507,6 +507,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     )
 
     when(audioRepository.withId(audioId)).thenReturn(Some(audio))
+    when(audioStorage.deleteObject(any[String])).thenReturn(Success(()))
     when(audioRepository.update(any[domain.AudioMetaInformation], eqTo(audioId))).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(
@@ -819,6 +820,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     )
 
     when(audioRepository.withId(audioId)).thenReturn(Some(audio))
+    when(audioStorage.deleteObject(any[String])).thenReturn(Success(()))
     when(audioRepository.update(any[domain.AudioMetaInformation], eqTo(audioId))).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -818,14 +818,13 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       )
     )
 
-
     when(audioRepository.withId(audioId)).thenReturn(Some(audio))
     when(audioRepository.update(any[domain.AudioMetaInformation], eqTo(audioId))).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
@@ -862,14 +861,13 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       )
     )
 
-
     when(audioRepository.withId(audioId)).thenReturn(Some(audio))
     when(audioRepository.update(any[domain.AudioMetaInformation], eqTo(audioId))).thenAnswer((i: InvocationOnMock) =>
       Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation]))
       .thenAnswer((i: InvocationOnMock) => Success(i.getArgument[domain.AudioMetaInformation](0)))
@@ -905,7 +903,6 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       )
     )
 
-
     val afterInsert = audio.copy(id = Some(5555), revision = Some(1))
 
     when(audioRepository.withId(5555)).thenReturn(Some(audio))
@@ -914,8 +911,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(s3ObjectMock))
     when(
       validationService.validate(any[domain.AudioMetaInformation],
-        any[Option[domain.AudioMetaInformation]],
-        any[Option[domain.Series]]))
+                                 any[Option[domain.AudioMetaInformation]],
+                                 any[Option[domain.Series]]))
       .thenReturn(Success(audio))
     when(audioRepository.update(any[domain.AudioMetaInformation], any[Long])).thenReturn(Success(afterInsert))
     when(audioIndexService.indexDocument(any[domain.AudioMetaInformation])).thenReturn(Success(afterInsert))
@@ -925,10 +922,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val result = writeService.updateAudio(5555, updatedAudioMeta, Some(fileMock1))
     result.isSuccess should be(true)
 
-
     verify(audioStorage, times(1)).deleteObject("file3.mp3")
 
   }
-
 
 }


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/Issues/issues/2724

To endring:
1. Ved sletting av språkversjon vil den tilhørende filen slettes dersom den ikke finnes i andre språk.
2. Ved opplasting av ny fil til et språk vil den gamle filen slettes dersom den ikke finnes i andre språk.

Tar gjerne tilbakemelding på plassering av `deleteFile` i bunnen av `updateAudio`. Den gamle filen kan hvertfall ikke slettes med mindre oppdateringen er vellykket.