### PR TITLE
Use ndla language package.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,9 @@ lazy val audio_api = (project in file("."))
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8", "-unchecked", "-deprecation", "-feature"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.44",
+      "ndla" %% "language" % "1.0.0",
       "ndla" %% "mapping" % "0.15",
+      "ndla" %% "network" % "0.44",
       "ndla" %% "scalatestsuite" % "0.3" % "test",
       "joda-time" % "joda-time" % "2.10",
       "org.scalatra" %% "scalatra" % Scalatraversion,

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/db/migration/V10__AudioTypeFromNumberToString.scala
+++ b/src/main/scala/db/migration/V10__AudioTypeFromNumberToString.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/src/main/scala/db/migration/V11__AddCreatedField.scala
+++ b/src/main/scala/db/migration/V11__AddCreatedField.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/src/main/scala/db/migration/V12__AddSeriesDateField.scala
+++ b/src/main/scala/db/migration/V12__AddSeriesDateField.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/src/main/scala/db/migration/V13__AddSeriesDescriptionField.scala
+++ b/src/main/scala/db/migration/V13__AddSeriesDescriptionField.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
+++ b/src/main/scala/db/migration/V14__CreateMissingFilePaths.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2021 NDLA
  *
  * See LICENSE

--- a/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
+++ b/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
@@ -28,8 +28,8 @@ class V15__ConvertLanguageUnknown extends BaseJavaMigration {
   }
 
   def convertDocument(document: String): String = {
-    val oldArticle = parse(document)
-    val extractedAudio = oldArticle.extract[V15_Audio]
+    val oldAudio = parse(document)
+    val extractedAudio = oldAudio.extract[V15_Audio]
     val tags = extractedAudio.tags.map(t => {
       if (t.language == "unknown")
         t.copy(language = "und")
@@ -54,7 +54,7 @@ class V15__ConvertLanguageUnknown extends BaseJavaMigration {
       else
         m
     })
-    val updated = oldArticle
+    val updated = oldAudio
       .replace(List("tags"), Extraction.decompose(tags))
       .replace(List("titles"), Extraction.decompose(titles))
       .replace(List("filePaths"), Extraction.decompose(filePaths))

--- a/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
+++ b/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
@@ -1,6 +1,6 @@
 /*
- * Part of NDLA audio_api.
- * Copyright (C) 2017 NDLA
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
  *
  * See LICENSE
  */

--- a/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
+++ b/src/main/scala/db/migration/V15__ConvertLanguageUnknown.scala
@@ -1,0 +1,88 @@
+/*
+ * Part of NDLA audio_api.
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, Extraction}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V15__ConvertLanguageUnknown extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      allAudios.map {
+        case (id: Long, document: String) => update(convertDocument(document), id)
+      }
+    }
+  }
+
+  def convertDocument(document: String): String = {
+    val oldArticle = parse(document)
+    val extractedAudio = oldArticle.extract[V15_Audio]
+    val tags = extractedAudio.tags.map(t => {
+      if (t.language == "unknown")
+        t.copy(language = "und")
+      else
+        t
+    })
+    val titles = extractedAudio.titles.map(t => {
+      if (t.language == "unknown")
+        t.copy(language = "und")
+      else
+        t
+    })
+    val filePaths = extractedAudio.filePaths.map(fp => {
+      if (fp.language == "unknown")
+        fp.copy(language = "und")
+      else
+        fp
+    })
+    val manuscript = extractedAudio.manuscript.map(m => {
+      if (m.language == "unknown")
+        m.copy(language = "und")
+      else
+        m
+    })
+    val updated = oldArticle
+      .replace(List("tags"), Extraction.decompose(tags))
+      .replace(List("titles"), Extraction.decompose(titles))
+      .replace(List("filePaths"), Extraction.decompose(filePaths))
+      .replace(List("manuscript"), Extraction.decompose(manuscript))
+    compact(render(updated))
+  }
+
+  def allAudios(implicit session: DBSession): List[(Long, String)] = {
+    sql"select id, document from audiodata"
+      .map(rs => (rs.long("id"), rs.string("document")))
+      .list()
+      .apply()
+  }
+
+  def update(document: String, id: Long)(implicit session: DBSession) = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update audiodata set document = ${dataObject} where id = $id".update().apply()
+  }
+
+  case class V15_Tags(tags: Seq[String], language: String)
+  case class V15_Titles(title: String, language: String)
+  case class V15_FilePaths(filePath: String, fileSize: Int, language: String, mimeType: String)
+  case class V15_Manuscript(manuscript: String, language: String)
+  case class V15_Audio(tags: Seq[V15_Tags],
+                       titles: Seq[V15_Titles],
+                       filePaths: Seq[V15_FilePaths],
+                       manuscript: Seq[V15_Manuscript])
+}

--- a/src/main/scala/db/migration/V2__AddUpdatedColoums.scala
+++ b/src/main/scala/db/migration/V2__AddUpdatedColoums.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/db/migration/V4__AddLanguageToAll.scala
+++ b/src/main/scala/db/migration/V4__AddLanguageToAll.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/db/migration/V4__AddLanguageToAll.scala
+++ b/src/main/scala/db/migration/V4__AddLanguageToAll.scala
@@ -28,10 +28,10 @@ class V4__AddLanguageToAll extends BaseJavaMigration {
 
   def convertAudioUpdate(audioMeta: V4_AudioMetaInformation): V4_AudioMetaInformation = {
     audioMeta.copy(
-      titles = audioMeta.titles.map(t => V4_Title(t.title, Some(Language.languageOrUnknown(t.language)))),
+      titles = audioMeta.titles.map(t => V4_Title(t.title, Some(Language.languageOrUnknown(t.language).toString()))),
       filePaths = audioMeta.filePaths.map(f =>
-        V4_Audio(f.filePath, f.mimeType, f.fileSize, Some(Language.languageOrUnknown(f.language)))),
-      tags = audioMeta.tags.map(t => V4_Tag(t.tags, Some(Language.languageOrUnknown(t.language))))
+        V4_Audio(f.filePath, f.mimeType, f.fileSize, Some(Language.languageOrUnknown(f.language).toString()))),
+      tags = audioMeta.tags.map(t => V4_Tag(t.tags, Some(Language.languageOrUnknown(t.language).toString())))
     )
   }
 

--- a/src/main/scala/db/migration/V5__AddAgreementToAudio.scala
+++ b/src/main/scala/db/migration/V5__AddAgreementToAudio.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/db/migration/V6__TranslateUntranslatedAuthors.scala
+++ b/src/main/scala/db/migration/V6__TranslateUntranslatedAuthors.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
+++ b/src/main/scala/no/ndla/audioapi/AudioApiProperties.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/AudioSwagger.scala
+++ b/src/main/scala/no/ndla/audioapi/AudioSwagger.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/audioapi/ComponentRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/DBMigrator.scala
+++ b/src/main/scala/no/ndla/audioapi/DBMigrator.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/JettyLauncher.scala
+++ b/src/main/scala/no/ndla/audioapi/JettyLauncher.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/auth/Role.scala
+++ b/src/main/scala/no/ndla/audioapi/auth/Role.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/auth/User.scala
+++ b/src/main/scala/no/ndla/audioapi/auth/User.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/caching/Memoize.scala
+++ b/src/main/scala/no/ndla/audioapi/caching/Memoize.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/AudioController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/CorrelationIdSupport.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/CorrelationIdSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/HealthController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/InternController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/NdlaController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/controller/SeriesController.scala
+++ b/src/main/scala/no/ndla/audioapi/controller/SeriesController.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/integration/AmazonClient.scala
+++ b/src/main/scala/no/ndla/audioapi/integration/AmazonClient.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/integration/DataSource.scala
+++ b/src/main/scala/no/ndla/audioapi/integration/DataSource.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/integration/Elastic4sClient.scala
+++ b/src/main/scala/no/ndla/audioapi/integration/Elastic4sClient.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2018 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/Language.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Language.scala
@@ -18,7 +18,7 @@ import scala.annotation.tailrec
 object Language {
   val UnknownLanguage: LanguageTag = LanguageTag("und") // Undefined
   val DefaultLang: LanguageTag = LanguageTag(DefaultLanguage)
-  val AllLanguages = "all"
+  val AllLanguages = "*"
   val NoLanguage = ""
 
   val languageAnalyzers = Seq(
@@ -62,8 +62,6 @@ object Language {
     LanguageAnalyzer(LanguageTag("tr"), TurkishLanguageAnalyzer),
     LanguageAnalyzer(UnknownLanguage, StandardAnalyzer)
   )
-
-  val supportedLanguages: Seq[LanguageTag] = languageAnalyzers.map(_.languageTag)
 
   def findByLanguageOrBestEffort[P <: WithLanguage](sequence: Seq[P], lang: Option[String]): Option[P] = {
     @tailrec

--- a/src/main/scala/no/ndla/audioapi/model/Language.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Language.scala
@@ -11,29 +11,60 @@ package no.ndla.audioapi.model
 import com.sksamuel.elastic4s.analyzers._
 import no.ndla.audioapi.AudioApiProperties.DefaultLanguage
 import no.ndla.audioapi.model.domain.{LanguageField, WithLanguage}
+import no.ndla.language.model.LanguageTag
 import no.ndla.mapping.ISO639
 
 import scala.annotation.tailrec
 
 object Language {
-  val UnknownLanguage = "unknown"
+  val UnknownLanguage: LanguageTag = LanguageTag("und") // Undefined
+  val DefaultLang: LanguageTag = LanguageTag(DefaultLanguage)
   val AllLanguages = "all"
   val NoLanguage = ""
 
   val languageAnalyzers = Seq(
-    LanguageAnalyzer("nb", NorwegianLanguageAnalyzer),
-    LanguageAnalyzer("nn", NorwegianLanguageAnalyzer),
-    LanguageAnalyzer("en", EnglishLanguageAnalyzer),
-    LanguageAnalyzer("fr", FrenchLanguageAnalyzer),
-    LanguageAnalyzer("de", GermanLanguageAnalyzer),
-    LanguageAnalyzer("es", SpanishLanguageAnalyzer),
-    LanguageAnalyzer("se", StandardAnalyzer), // SAMI
-    LanguageAnalyzer("sma", StandardAnalyzer), // SAMI
-    LanguageAnalyzer("zh", ChineseLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ar"), ArabicLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("hy"), ArmenianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("eu"), BasqueLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("pt-br"), BrazilianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("bg"), BulgarianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ca"), CatalanLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ja"), CjkLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ko"), CjkLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("zh"), CjkLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("cs"), CzechLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("da"), DanishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("nl"), DutchLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("en"), EnglishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("fi"), FinnishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("fr"), FrenchLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("gl"), GalicianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("de"), GermanLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("el"), GreekLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("hi"), HindiLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("hu"), HungarianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("id"), IndonesianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ga"), IrishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("it"), ItalianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("lt"), LithuanianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("lv"), LatvianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("nb"), NorwegianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("nn"), NorwegianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("fa"), PersianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("pt"), PortugueseLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ro"), RomanianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("ru"), RussianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("se"), StandardAnalyzer), // Northern Sami
+    LanguageAnalyzer(LanguageTag("sma"), StandardAnalyzer), // Southern sami
+    LanguageAnalyzer(LanguageTag("srb"), SoraniLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("es"), SpanishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("sv"), SwedishLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("th"), ThaiLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("tr"), TurkishLanguageAnalyzer),
     LanguageAnalyzer(UnknownLanguage, StandardAnalyzer)
   )
 
-  val supportedLanguages: Seq[String] = languageAnalyzers.map(_.lang)
+  val supportedLanguages: Seq[LanguageTag] = languageAnalyzers.map(_.languageTag)
 
   def findByLanguageOrBestEffort[P <: WithLanguage](sequence: Seq[P], lang: Option[String]): Option[P] = {
     @tailrec
@@ -60,10 +91,11 @@ object Language {
   def findByLanguage[T](sequence: Seq[LanguageField[T]], lang: String): Option[T] =
     sequence.find(_.language == lang).map(_.value)
 
-  def languageOrUnknown(language: Option[String]): String = {
+  def languageOrUnknown(language: Option[String]): LanguageTag = {
     language.filter(_.nonEmpty) match {
-      case Some(x) => x
-      case None    => UnknownLanguage
+      case Some(x) if x == "unknown" => UnknownLanguage
+      case Some(x)                   => LanguageTag(x)
+      case None                      => UnknownLanguage
     }
   }
 
@@ -74,4 +106,4 @@ object Language {
   }
 }
 
-case class LanguageAnalyzer(lang: String, analyzer: Analyzer)
+case class LanguageAnalyzer(languageTag: LanguageTag, analyzer: Analyzer)

--- a/src/main/scala/no/ndla/audioapi/model/Language.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Language.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/Language.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Language.scala
@@ -12,7 +12,6 @@ import com.sksamuel.elastic4s.analyzers._
 import no.ndla.audioapi.AudioApiProperties.DefaultLanguage
 import no.ndla.audioapi.model.domain.{LanguageField, WithLanguage}
 import no.ndla.language.model.LanguageTag
-import no.ndla.mapping.ISO639
 
 import scala.annotation.tailrec
 
@@ -23,6 +22,11 @@ object Language {
   val NoLanguage = ""
 
   val languageAnalyzers = Seq(
+    LanguageAnalyzer(LanguageTag("nb"), NorwegianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("nn"), NorwegianLanguageAnalyzer),
+    LanguageAnalyzer(LanguageTag("sma"), StandardAnalyzer), // Southern sami
+    LanguageAnalyzer(LanguageTag("se"), StandardAnalyzer), // Northern Sami
+    LanguageAnalyzer(LanguageTag("en"), EnglishLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("ar"), ArabicLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("hy"), ArmenianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("eu"), BasqueLanguageAnalyzer),
@@ -35,7 +39,6 @@ object Language {
     LanguageAnalyzer(LanguageTag("cs"), CzechLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("da"), DanishLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("nl"), DutchLanguageAnalyzer),
-    LanguageAnalyzer(LanguageTag("en"), EnglishLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("fi"), FinnishLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("fr"), FrenchLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("gl"), GalicianLanguageAnalyzer),
@@ -48,14 +51,10 @@ object Language {
     LanguageAnalyzer(LanguageTag("it"), ItalianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("lt"), LithuanianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("lv"), LatvianLanguageAnalyzer),
-    LanguageAnalyzer(LanguageTag("nb"), NorwegianLanguageAnalyzer),
-    LanguageAnalyzer(LanguageTag("nn"), NorwegianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("fa"), PersianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("pt"), PortugueseLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("ro"), RomanianLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("ru"), RussianLanguageAnalyzer),
-    LanguageAnalyzer(LanguageTag("se"), StandardAnalyzer), // Northern Sami
-    LanguageAnalyzer(LanguageTag("sma"), StandardAnalyzer), // Southern sami
     LanguageAnalyzer(LanguageTag("srb"), SoraniLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("es"), SpanishLanguageAnalyzer),
     LanguageAnalyzer(LanguageTag("sv"), SwedishLanguageAnalyzer),
@@ -85,7 +84,10 @@ object Language {
   def findLanguagePrioritized[P <: WithLanguage](sequence: Seq[P], language: String): Option[P] = {
     sequence
       .find(_.language == language)
-      .orElse(sequence.sortBy(lf => ISO639.languagePriority.reverse.indexOf(lf.language)).lastOption)
+      .orElse(
+        sequence
+          .sortBy(lf => languageAnalyzers.map(la => la.languageTag.toString()).reverse.indexOf(lf.language))
+          .lastOption)
   }
 
   def findByLanguage[T](sequence: Seq[LanguageField[T]], lang: String): Option[T] =
@@ -101,7 +103,7 @@ object Language {
 
   def getSupportedLanguages[P <: WithLanguage](sequences: Seq[P]*): Seq[String] = {
     sequences.flatMap(_.map(_.language)).distinct.sortBy { lang =>
-      ISO639.languagePriority.indexOf(lang)
+      languageAnalyzers.map(la => la.languageTag).indexOf(LanguageTag(lang))
     }
   }
 }

--- a/src/main/scala/no/ndla/audioapi/model/Sort.scala
+++ b/src/main/scala/no/ndla/audioapi/model/Sort.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/api/Audio.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Audio.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/AudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/AudioMetaInformation.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/api/AudioSummary.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/AudioSummary.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/Author.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Author.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModelProperty

--- a/src/main/scala/no/ndla/audioapi/model/api/Copyright.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Copyright.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import java.util.Date

--- a/src/main/scala/no/ndla/audioapi/model/api/CoverPhoto.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/CoverPhoto.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Error.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/api/License.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/License.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/Manuscript.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Manuscript.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty

--- a/src/main/scala/no/ndla/audioapi/model/api/NewAudioFile.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/NewAudioFile.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}

--- a/src/main/scala/no/ndla/audioapi/model/api/NewAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/NewAudioMetaInformation.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/api/NewPodcastMeta.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/NewPodcastMeta.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/PodcastMeta.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/PodcastMeta.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/SearchParams.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/SearchParams.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/api/SearchResult.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/SearchResult.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/Tag.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Tag.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.annotations.ApiModel

--- a/src/main/scala/no/ndla/audioapi/model/api/Title.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/Title.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.api
 
 import org.scalatra.swagger.runtime.annotations.ApiModelProperty

--- a/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/api/UpdatedAudioMetaInformation.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/domain/AudioMetaInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/AudioMetaInformation.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/SearchSettings.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.domain
 
 import no.ndla.audioapi.model.Sort

--- a/src/main/scala/no/ndla/audioapi/model/domain/SeriesSearchSettings.scala
+++ b/src/main/scala/no/ndla/audioapi/model/domain/SeriesSearchSettings.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model.domain
 
 import no.ndla.audioapi.model.Sort

--- a/src/main/scala/no/ndla/audioapi/model/search/SearchableAudioInformation.scala
+++ b/src/main/scala/no/ndla/audioapi/model/search/SearchableAudioInformation.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/search/SearchableLanguageFields.scala
+++ b/src/main/scala/no/ndla/audioapi/model/search/SearchableLanguageFields.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/search/SearchableSeries.scala
+++ b/src/main/scala/no/ndla/audioapi/model/search/SearchableSeries.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/model/search/package.scala
+++ b/src/main/scala/no/ndla/audioapi/model/search/package.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.model
 
 import no.ndla.audioapi.model.domain.WithLanguage

--- a/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
+++ b/src/main/scala/no/ndla/audioapi/repository/AudioRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/AudioStorageService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/AudioStorageService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/Clock.scala
+++ b/src/main/scala/no/ndla/audioapi/service/Clock.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ConverterService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ReadService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
@@ -14,7 +14,7 @@ import no.ndla.audioapi.integration.DraftApiClient
 import no.ndla.audioapi.model.api.{ValidationException, ValidationMessage}
 import no.ndla.audioapi.model.domain
 import no.ndla.audioapi.model.domain._
-import no.ndla.mapping.ISO639.get6391CodeFor6392CodeMappings
+import no.ndla.language.model.Iso639
 import no.ndla.mapping.License.getLicense
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
@@ -186,7 +186,7 @@ trait ValidationService {
           Seq(
             ValidationMessage(
               fieldName,
-              s"Podcast cover images must be minimum $minImageSize and maximum $maxImageSize to be valid. The supplied image was ${imageWidth}x${imageHeight}."
+              s"Podcast cover images must be minimum $minImageSize and maximum $maxImageSize to be valid. The supplied image was ${imageWidth}x$imageHeight."
             ))
 
       squareValidationMessage ++ sizeValidationMessage
@@ -211,9 +211,9 @@ trait ValidationService {
           ValidationMessage("podcastMeta",
                             s"Cannot specify podcastMeta fields for audioType other than '${AudioType.Podcast}'"))
       } else {
-        meta.flatMap(m => {
+        meta.flatMap(f = m => {
           val introductionErrors = validateNonEmpty("podcastMeta.introduction", m.introduction).toSeq
-          val coverPhotoErrors = if (language.exists(_ == m.language)) {
+          val coverPhotoErrors = if (language.contains(m.language)) {
             validatePodcastCoverPhoto("podcastMeta.coverPhoto", m.coverPhoto)
           } else Seq.empty
 
@@ -305,8 +305,7 @@ trait ValidationService {
       }
     }
 
-    private def languageCodeSupported6391(languageCode: String): Boolean =
-      get6391CodeFor6392CodeMappings.exists(_._2 == languageCode)
+    private def languageCodeSupported6391(languageCode: String): Boolean = Iso639.get(languageCode).isSuccess
 
     private def validateNonEmpty(fieldPath: String, option: Option[_]): Option[ValidationMessage] = {
       option match {

--- a/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
@@ -211,7 +211,7 @@ trait ValidationService {
           ValidationMessage("podcastMeta",
                             s"Cannot specify podcastMeta fields for audioType other than '${AudioType.Podcast}'"))
       } else {
-        meta.flatMap(f = m => {
+        meta.flatMap(m => {
           val introductionErrors = validateNonEmpty("podcastMeta.introduction", m.introduction).toSeq
           val coverPhotoErrors = if (language.contains(m.language)) {
             validatePodcastCoverPhoto("podcastMeta.coverPhoto", m.coverPhoto)

--- a/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/ValidationService.scala
@@ -298,14 +298,14 @@ trait ValidationService {
     private def validateLanguage(fieldPath: String,
                                  languageCode: String,
                                  oldLanguages: Seq[String]): Option[ValidationMessage] = {
-      if (languageCodeSupported6391(languageCode) || oldLanguages.contains(languageCode)) {
+      if (languageCodeSupported639(languageCode) || oldLanguages.contains(languageCode)) {
         None
       } else {
         Some(ValidationMessage(fieldPath, s"Language '$languageCode' is not a supported value."))
       }
     }
 
-    private def languageCodeSupported6391(languageCode: String): Boolean = Iso639.get(languageCode).isSuccess
+    private def languageCodeSupported639(languageCode: String): Boolean = Iso639.get(languageCode).isSuccess
 
     private def validateNonEmpty(fieldPath: String, option: Option[_]): Option[ValidationMessage] = {
       option match {

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.service
 
 import cats.implicits._

--- a/src/main/scala/no/ndla/audioapi/service/search/AudioIndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/AudioIndexService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
@@ -9,23 +9,19 @@
 package no.ndla.audioapi.service.search
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
-import com.sksamuel.elastic4s.searches.queries.{BoolQuery, Query}
+import com.sksamuel.elastic4s.searches.queries.BoolQuery
 import com.typesafe.scalalogging.LazyLogging
-import no.ndla.audioapi.AudioApiProperties
 import no.ndla.audioapi.AudioApiProperties.{
   ElasticSearchIndexMaxResultWindow,
   ElasticSearchScrollKeepAlive,
   SearchIndex
 }
 import no.ndla.audioapi.integration.Elastic4sClient
-import no.ndla.audioapi.model.Language._
-import no.ndla.audioapi.model.api.{AudioSummary, ResultWindowTooLargeException, Title}
+import no.ndla.audioapi.model.api.ResultWindowTooLargeException
 import no.ndla.audioapi.model.domain.SearchSettings
 import no.ndla.audioapi.model.search.{SearchableAudioInformation, SearchableLanguageFormats}
 import no.ndla.audioapi.model.{Language, api, domain}
-import no.ndla.network.ApplicationUrl
 import org.json4s._
-import org.json4s.native.JsonMethods._
 import org.json4s.native.Serialization
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -81,8 +77,9 @@ trait AudioSearchService {
       }
 
       val (languageFilter, searchLanguage) = settings.language match {
-        case Some(lang) if Language.supportedLanguages.contains(lang) => (Some(existsQuery(s"titles.$lang")), lang)
-        case _                                                        => (None, "*")
+        case Some(lang) if Language.supportedLanguages.map(l => l.toString()).contains(lang) =>
+          (Some(existsQuery(s"titles.$lang")), lang)
+        case _ => (None, "*")
       }
 
       val audioTypeFilter = settings.audioType match {

--- a/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/AudioSearchService.scala
@@ -77,9 +77,8 @@ trait AudioSearchService {
       }
 
       val (languageFilter, searchLanguage) = settings.language match {
-        case Some(lang) if Language.supportedLanguages.map(l => l.toString()).contains(lang) =>
-          (Some(existsQuery(s"titles.$lang")), lang)
-        case _ => (None, "*")
+        case Some(lang) => (Some(existsQuery(s"titles.$lang")), lang)
+        case _          => (None, "*")
       }
 
       val audioTypeFilter = settings.audioType match {
@@ -120,7 +119,7 @@ trait AudioSearchService {
                   response.result.totalHits,
                   Some(settings.page.getOrElse(1)),
                   numResults,
-                  if (searchLanguage == "*") Language.AllLanguages else searchLanguage,
+                  searchLanguage,
                   results,
                   response.result.scrollId
               ))

--- a/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
@@ -8,24 +8,22 @@
 
 package no.ndla.audioapi.service.search
 
+import cats.implicits._
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexRequest
-import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition, NestedField}
+import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.audioapi.AudioApiProperties
 import no.ndla.audioapi.integration.Elastic4sClient
 import no.ndla.audioapi.model.Language._
-import no.ndla.audioapi.model.domain.{AudioMetaInformation, ReindexResult}
+import no.ndla.audioapi.model.domain.ReindexResult
 import no.ndla.audioapi.model.search.SearchableLanguageFormats
 import no.ndla.audioapi.repository.{AudioRepository, Repository}
 import org.json4s.Formats
-import org.json4s.native.Serialization.write
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import scala.util.{Failure, Success, Try}
-
-import cats.implicits._
 
 trait IndexService {
   this: Elastic4sClient with SearchConverterService with AudioRepository =>
@@ -250,12 +248,12 @@ trait IndexService {
       if (keepRaw) {
         languageAnalyzers.map(
           langAnalyzer =>
-            textField(s"$fieldName.${langAnalyzer.lang}")
+            textField(s"$fieldName.${langAnalyzer.languageTag.toString()}")
               .analyzer(langAnalyzer.analyzer)
               .fields(keywordField("raw")))
       } else {
         languageAnalyzers.map(langAnalyzer =>
-          textField(s"$fieldName.${langAnalyzer.lang}").analyzer(langAnalyzer.analyzer))
+          textField(s"$fieldName.${langAnalyzer.languageTag.toString()}").analyzer(langAnalyzer.analyzer))
       }
     }
 

--- a/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
@@ -9,8 +9,10 @@
 package no.ndla.audioapi.service.search
 
 import cats.implicits._
+import com.sksamuel.elastic4s.analyzers.StandardAnalyzer
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexRequest
+import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicTemplateRequest
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.audioapi.AudioApiProperties
@@ -23,6 +25,7 @@ import org.json4s.Formats
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
+import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 
 trait IndexService {
@@ -236,7 +239,7 @@ trait IndexService {
     def getTimestamp: String = new SimpleDateFormat("yyyyMMddHHmmss").format(Calendar.getInstance.getTime)
 
     /**
-      * Returns Sequence of FieldDefinitions for a given field.
+      * @deprecated Returns Sequence of FieldDefinitions for a given field.
       *
       * @param fieldName Name of field in mapping.
       * @param keepRaw   Whether to add a keywordField named raw.
@@ -255,6 +258,40 @@ trait IndexService {
         languageAnalyzers.map(langAnalyzer =>
           textField(s"$fieldName.${langAnalyzer.languageTag.toString()}").analyzer(langAnalyzer.analyzer))
       }
+    }
+
+    /**
+      * Returns Sequence of DynamicTemplateRequest for a given field.
+      *
+      * @param fieldName Name of field in mapping.
+      * @param keepRaw   Whether to add a keywordField named raw.
+      *                  Usually used for sorting, aggregations or scripts.
+      * @return Sequence of DynamicTemplateRequest for a field.
+      */
+    protected def generateLanguageSupportedDynamicTemplates(fieldName: String,
+                                                            keepRaw: Boolean = false): Seq[DynamicTemplateRequest] = {
+      val fields = new ListBuffer[FieldDefinition]()
+      if (keepRaw) {
+        fields += keywordField("raw")
+      }
+      val languageTemplates = languageAnalyzers.map(
+        languageAnalyzer => {
+          val name = s"$fieldName.${languageAnalyzer.languageTag.toString()}"
+          DynamicTemplateRequest(
+            name = name,
+            mapping = textField(name).analyzer(languageAnalyzer.analyzer).fields(fields.toList),
+            matchMappingType = Some("string"),
+            pathMatch = Some(name)
+          )
+        }
+      )
+      val catchAlltemplate = DynamicTemplateRequest(
+        name = fieldName,
+        mapping = textField(fieldName).analyzer(StandardAnalyzer).fields(fields.toList),
+        matchMappingType = Some("string"),
+        pathMatch = Some(s"$fieldName.*")
+      )
+      languageTemplates ++ Seq(catchAlltemplate)
     }
 
   }

--- a/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/IndexService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
@@ -8,26 +8,19 @@
 
 package no.ndla.audioapi.service.search
 
+import cats.implicits._
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.audioapi.AudioApiProperties.{AudioControllerPath, Domain}
 import no.ndla.audioapi.model.Language.{findByLanguageOrBestEffort, getSupportedLanguages}
-import no.ndla.audioapi.model.api.{MissingIdException, Title}
-import no.ndla.audioapi.model.{Language, api, domain}
+import no.ndla.audioapi.model.api.Title
 import no.ndla.audioapi.model.domain.{AudioMetaInformation, SearchResult, SearchableTag}
-import no.ndla.audioapi.model.search.{
-  LanguageValue,
-  SearchableAudioInformation,
-  SearchableLanguageList,
-  SearchableLanguageValues,
-  SearchablePodcastMeta,
-  SearchableSeries
-}
+import no.ndla.audioapi.model.search._
+import no.ndla.audioapi.model.{Language, api, domain}
 import no.ndla.audioapi.service.ConverterService
 import no.ndla.mapping.ISO639
 
-import scala.util.{Failure, Success, Try}
-import cats.implicits._
+import scala.util.Try
 
 trait SearchConverterService {
   this: ConverterService =>
@@ -126,7 +119,7 @@ trait SearchConverterService {
 
       val defaultTitle = metaWithAgreement.titles
         .sortBy(title => {
-          val languagePriority = Language.languageAnalyzers.map(la => la.lang).reverse
+          val languagePriority = Language.languageAnalyzers.map(la => la.languageTag.toString()).reverse
           languagePriority.indexOf(title.language)
         })
         .lastOption

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchConverterService.scala
@@ -18,7 +18,6 @@ import no.ndla.audioapi.model.domain.{AudioMetaInformation, SearchResult, Search
 import no.ndla.audioapi.model.search._
 import no.ndla.audioapi.model.{Language, api, domain}
 import no.ndla.audioapi.service.ConverterService
-import no.ndla.mapping.ISO639
 
 import scala.util.Try
 
@@ -164,7 +163,7 @@ trait SearchConverterService {
 
         keyLanguages
           .sortBy(lang => {
-            ISO639.languagePriority.reverse.indexOf(lang)
+            Language.languageAnalyzers.map(la => la.languageTag.toString()).reverse.indexOf(lang)
           })
           .lastOption
       }

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchIndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchIndexService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SearchService.scala
@@ -17,6 +17,7 @@ import no.ndla.audioapi.AudioApiProperties.{DefaultPageSize, ElasticSearchScroll
 import no.ndla.audioapi.integration.Elastic4sClient
 import no.ndla.audioapi.model.domain.{NdlaSearchException, SearchResult}
 import no.ndla.audioapi.model.{Language, Sort}
+import no.ndla.language.model.Iso639
 import org.elasticsearch.ElasticsearchException
 import org.elasticsearch.index.IndexNotFoundException
 
@@ -39,7 +40,7 @@ trait SearchService {
               totalCount = response.result.totalHits,
               page = None,
               pageSize = response.result.hits.hits.length,
-              language = if (language == "*") Language.AllLanguages else language,
+              language,
               results = hits,
               scrollId = response.result.scrollId
             )
@@ -51,7 +52,7 @@ trait SearchService {
                                          query: String,
                                          boost: Float): Query = {
       language match {
-        case Some(lang) if Language.supportedLanguages.map(l => l.toString()).contains(lang) =>
+        case Some(lang) if Iso639.get(lang).isSuccess =>
           simpleStringQuery(query).field(s"$searchField.$lang", boost)
         case _ =>
           simpleStringQuery(query).field(s"$searchField.*", boost)
@@ -67,7 +68,7 @@ trait SearchService {
 
           resultArray.traverse(result => {
             val matchedLanguage = language match {
-              case Language.AllLanguages | "*" =>
+              case Language.AllLanguages =>
                 searchConverterService.getLanguageFromHit(result).getOrElse(language)
               case _ => language
             }
@@ -80,7 +81,7 @@ trait SearchService {
 
     protected def getSortDefinition(sort: Sort.Value, language: String): FieldSort = {
       val sortLanguage = language match {
-        case supportedLanguage if Language.supportedLanguages.map(l => l.toString()).contains(supportedLanguage) =>
+        case supportedLanguage if Iso639.get(supportedLanguage).isSuccess =>
           supportedLanguage
         case _ => "*"
       }
@@ -89,12 +90,12 @@ trait SearchService {
         case Sort.ByTitleAsc =>
           sortLanguage match {
             case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.Asc).missing("_last")
-            case _   => fieldSort(s"titles.$sortLanguage.raw").order(SortOrder.Asc).missing("_last")
+            case _   => fieldSort(s"titles.$sortLanguage.raw").order(SortOrder.Asc).missing("_last").unmappedType("long")
           }
         case Sort.ByTitleDesc =>
           sortLanguage match {
             case "*" => fieldSort("defaultTitle").sortOrder(SortOrder.Desc).missing("_last")
-            case _   => fieldSort(s"titles.$sortLanguage.raw").order(SortOrder.Desc).missing("_last")
+            case _   => fieldSort(s"titles.$sortLanguage.raw").order(SortOrder.Desc).missing("_last").unmappedType("long")
           }
         case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
         case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
@@ -107,8 +108,8 @@ trait SearchService {
 
     def getSortDefinition(sort: Sort.Value): FieldSort = {
       sort match {
-        case Sort.ByTitleAsc        => fieldSort("title.raw").order(SortOrder.Asc).missing("_last")
-        case Sort.ByTitleDesc       => fieldSort("title.raw").order(SortOrder.Desc).missing("_last")
+        case Sort.ByTitleAsc        => fieldSort("title.raw").order(SortOrder.Asc).missing("_last").unmappedType("long")
+        case Sort.ByTitleDesc       => fieldSort("title.raw").order(SortOrder.Desc).missing("_last").unmappedType("long")
         case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
         case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
         case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")

--- a/src/main/scala/no/ndla/audioapi/service/search/SeriesIndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SeriesIndexService.scala
@@ -10,14 +10,14 @@ package no.ndla.audioapi.service.search
 
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexRequest
+import com.sksamuel.elastic4s.mappings.dynamictemplate.DynamicTemplateRequest
 import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.audioapi.AudioApiProperties
 import no.ndla.audioapi.integration.Elastic4sClient
-import no.ndla.audioapi.model.domain.{AudioMetaInformation, Series}
-import no.ndla.audioapi.model.search.{SearchableAudioInformation, SearchableLanguageFormats, SearchableSeries}
-import no.ndla.audioapi.repository.{AudioRepository, SeriesRepository}
-import org.json4s.Formats
+import no.ndla.audioapi.model.domain.Series
+import no.ndla.audioapi.model.search.SearchableSeries
+import no.ndla.audioapi.repository.SeriesRepository
 import org.json4s.native.Serialization.write
 
 import scala.util.{Failure, Success, Try}
@@ -46,11 +46,13 @@ trait SeriesIndexService {
         intField("id"),
         keywordField("defaultTitle"),
         dateField("lastUpdated"),
-      ) ++
-        generateLanguageSupportedFieldList("titles", keepRaw = true) ++
-        generateLanguageSupportedFieldList("descriptions", keepRaw = true)
+      )
 
-    def getMapping: MappingDefinition = mapping(documentType).fields(seriesIndexFields)
+    val seriesDynamics: Seq[DynamicTemplateRequest] =
+      generateLanguageSupportedDynamicTemplates("titles", keepRaw = true) ++
+        generateLanguageSupportedDynamicTemplates("descriptions", keepRaw = true)
+
+    def getMapping: MappingDefinition = mapping(documentType).fields(seriesIndexFields).dynamicTemplates(seriesDynamics)
   }
 
 }

--- a/src/main/scala/no/ndla/audioapi/service/search/SeriesIndexService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SeriesIndexService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/SeriesSearchService.scala
@@ -105,7 +105,7 @@ trait SeriesSearchService {
                   response.result.totalHits,
                   Some(settings.page.getOrElse(1)),
                   numResults,
-                  if (searchLanguage == "*") Language.AllLanguages else searchLanguage,
+                  searchLanguage,
                   hits,
                   response.result.scrollId
               ))

--- a/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
@@ -20,6 +20,7 @@ import no.ndla.audioapi.integration.Elastic4sClient
 import no.ndla.audioapi.model.Language
 import no.ndla.audioapi.model.api.ResultWindowTooLargeException
 import no.ndla.audioapi.model.domain.{SearchResult, SearchableTag}
+import no.ndla.language.model.{Iso639, LanguageTag}
 import org.json4s._
 import org.json4s.native.Serialization.read
 
@@ -45,8 +46,8 @@ trait TagSearchService {
 
     def matchingQuery(query: String, searchLanguage: String, page: Int, pageSize: Int): Try[SearchResult[String]] = {
       val language = searchLanguage match {
-        case lang if Language.supportedLanguages.map(l => l.toString()).contains(lang) => lang
-        case _                                                                         => "*"
+        case lang if Iso639.get(lang).isSuccess => lang
+        case _                                  => "*"
       }
 
       val fullQuery = boolQuery()
@@ -68,7 +69,7 @@ trait TagSearchService {
     ): Try[SearchResult[String]] = {
 
       val languageFilter =
-        if (language == "all" || language == "*") None
+        if (language == "*") None
         else
           Some(
             termQuery("language", language)
@@ -101,7 +102,7 @@ trait TagSearchService {
                   response.result.totalHits,
                   Some(page),
                   numResults,
-                  if (language == "*") Language.AllLanguages else language,
+                  language,
                   hits,
                   response.result.scrollId
               ))

--- a/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/search/TagSearchService.scala
@@ -45,8 +45,8 @@ trait TagSearchService {
 
     def matchingQuery(query: String, searchLanguage: String, page: Int, pageSize: Int): Try[SearchResult[String]] = {
       val language = searchLanguage match {
-        case lang if Language.supportedLanguages.contains(lang) => lang
-        case _                                                  => "*"
+        case lang if Language.supportedLanguages.map(l => l.toString()).contains(lang) => lang
+        case _                                                                         => "*"
       }
 
       val fullQuery = boolQuery()

--- a/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
+++ b/src/test/scala/db/migration/V14__CreateMissingFilePathsTest.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import no.ndla.audioapi.{TestEnvironment, UnitSuite}

--- a/src/test/scala/db/migration/V15__ConvertLanguageUnknownTest.scala
+++ b/src/test/scala/db/migration/V15__ConvertLanguageUnknownTest.scala
@@ -1,0 +1,20 @@
+package db.migration
+
+import no.ndla.audioapi.{TestEnvironment, UnitSuite}
+
+class V15__ConvertLanguageUnknownTest extends UnitSuite with TestEnvironment {
+  val migration = new V15__ConvertLanguageUnknown
+
+  test("migration should change unknown to und") {
+    {
+      val old =
+        s"""{"tags":[{"tags":["fence"],"language":"unknown"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"unknown"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"unknown","mimeType":"audio/mpeg"},{"filePath":"file1.mp3","fileSize":6326273,"language":"nb","mimeType":"audio/mpeg"}],"manuscript":[{"manuscript":"Manuscript","language":"unknown"},{"manuscript":"Manuscript","language":"nb"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      val expected =
+        s"""{"tags":[{"tags":["fence"],"language":"und"},{"tags":["gjerde"],"language":"nb"}],"titles":[{"title":"Saemie saajv","language":"und"},{"title":"Norsk","language":"nb"}],"updated":"2017-12-12T11:12:08Z","copyright":{"origin":"Fylkesbiblioteket","license":"by-sa","creators":[{"name":"A","type":"Writer"},{"name":"B","type":"Redaksjonelt"},{"name":"C","type":"Originator"}],"processors":[],"rightsholders":[]},"filePaths":[{"filePath":"file1.mp3","fileSize":6326273,"language":"und","mimeType":"audio/mpeg"},{"filePath":"file1.mp3","fileSize":6326273,"language":"nb","mimeType":"audio/mpeg"}],"manuscript":[{"manuscript":"Manuscript","language":"und"},{"manuscript":"Manuscript","language":"nb"}],"updatedBy":"swagger-client","supportedLanguages":null}"""
+
+      migration.convertDocument(old) should equal(expected)
+    }
+  }
+
+}

--- a/src/test/scala/db/migration/V15__ConvertLanguageUnknownTest.scala
+++ b/src/test/scala/db/migration/V15__ConvertLanguageUnknownTest.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import no.ndla.audioapi.{TestEnvironment, UnitSuite}

--- a/src/test/scala/db/migration/V2__AddUpdatedColoumsTest.scala
+++ b/src/test/scala/db/migration/V2__AddUpdatedColoumsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/test/scala/db/migration/V4__AddLanguageToAllTest.scala
+++ b/src/test/scala/db/migration/V4__AddLanguageToAllTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2017 NDLA
  *
  * See LICENSE

--- a/src/test/scala/db/migration/V4__AddLanguageToAllTest.scala
+++ b/src/test/scala/db/migration/V4__AddLanguageToAllTest.scala
@@ -24,11 +24,11 @@ class V4__AddLanguageToAllTest extends UnitSuite with TestEnvironment {
       V4_AudioMetaInformation(Some(1), Some(1), titles, filePaths, V4_Copyright("", None, Seq()), tags, "", new Date())
     val after = migration.convertAudioUpdate(before)
 
-    after.titles.head.language should equal(Some("unknown"))
+    after.titles.head.language should equal(Some("und"))
     after.titles.last.language should equal(Some("nb"))
-    after.filePaths.head.language should equal(Some("unknown"))
+    after.filePaths.head.language should equal(Some("und"))
     after.filePaths.last.language should equal(Some("nb"))
     after.tags.head.language should equal(Some("en"))
-    after.tags.last.language should equal(Some("unknown"))
+    after.tags.last.language should equal(Some("und"))
   }
 }

--- a/src/test/scala/db/migration/V6__TranslateUntranslatedAuthorsTest.scala
+++ b/src/test/scala/db/migration/V6__TranslateUntranslatedAuthorsTest.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package db.migration
 
 import no.ndla.audioapi.{TestEnvironment, UnitSuite}

--- a/src/test/scala/no/ndla/audioapi/TestData.scala
+++ b/src/test/scala/no/ndla/audioapi/TestData.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi
 
 import no.ndla.audioapi.model.Sort

--- a/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
+++ b/src/test/scala/no/ndla/audioapi/TestEnvironment.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/audioapi/UnitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/caching/MemoizeTest.scala
+++ b/src/test/scala/no/ndla/audioapi/caching/MemoizeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/controller/AudioControllerTest.scala
+++ b/src/test/scala/no/ndla/audioapi/controller/AudioControllerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/controller/HealthControllerTest.scala
+++ b/src/test/scala/no/ndla/audioapi/controller/HealthControllerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/audioapi/controller/InternControllerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/service/AudioStorageServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/AudioStorageServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/ConverterServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/service/ValidationServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/ValidationServiceTest.scala
@@ -14,15 +14,15 @@ import no.ndla.audioapi.{TestEnvironment, UnitSuite}
 import java.awt.image.BufferedImage
 
 class ValidationServiceTest extends UnitSuite with TestEnvironment {
-  override val validationService = spy(new ValidationService)
+  override val validationService: ValidationService = spy(new ValidationService)
 
   override def beforeEach(): Unit = {
     reset(validationService)
   }
 
-  val audioType = AudioType.Podcast
-  val enCoverPhoto = CoverPhoto("1", "alt")
-  val nbCoverPhoto = CoverPhoto("2", "alt")
+  val audioType: AudioType.Value = AudioType.Podcast
+  val enCoverPhoto: CoverPhoto = CoverPhoto("1", "alt")
+  val nbCoverPhoto: CoverPhoto = CoverPhoto("2", "alt")
   val meta = Seq(PodcastMeta("intro", enCoverPhoto, "en"), PodcastMeta("intro", nbCoverPhoto, "nb"))
 
   test("validatePodcastMeta is empty when cover photo is squared") {

--- a/src/test/scala/no/ndla/audioapi/service/ValidationServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/ValidationServiceTest.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.audioapi.service
 
-import no.ndla.audioapi.model.domain.{AudioType, CoverPhoto, PodcastMeta}
+import no.ndla.audioapi.model.domain.{AudioType, CoverPhoto, PodcastMeta, Tag}
 import no.ndla.audioapi.{TestEnvironment, UnitSuite}
 
 import java.awt.image.BufferedImage
@@ -55,6 +55,29 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
 
     result.length should be(1)
 
+  }
+
+  test("validateLanguage approves all kinds of languages") {
+    val nbTag = Tag(Seq("Tag1", "Tag2"), "nb")
+    val nnTag = Tag(Seq("Tag1", "Tag2"), "nn")
+    val undTag = Tag(Seq("Tag1", "Tag2"), "und")
+    val result = validationService.validateTags(Seq(nbTag, nnTag, undTag), Seq.empty)
+
+    result.length should be(0)
+  }
+
+  test("validateLanguage denies unknown") {
+    val undTag = Tag(Seq("Tag1", "Tag2"), "unknown")
+    val result = validationService.validateTags(Seq(undTag), Seq.empty)
+
+    result.length should be(1)
+  }
+
+  test("validateLanguage approves language without languageAnalzer") {
+    val undTag = Tag(Seq("Tag1", "Tag2"), "mix") // Mixtepec Mixtec
+    val result = validationService.validateTags(Seq(undTag), Seq.empty)
+
+    result.length should be(0)
   }
 
 }

--- a/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/WriteServiceTest.scala
@@ -1,3 +1,10 @@
+/*
+ * Part of NDLA audio-api
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
 package no.ndla.audioapi.service
 
 import com.amazonaws.services.s3.model.ObjectMetadata

--- a/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
@@ -54,6 +54,7 @@ class AudioSearchServiceTest
   val updated4: Date = new DateTime(2017, 7, 1, 12, 15, 32, DateTimeZone.UTC).toDate
   val updated5: Date = new DateTime(2017, 8, 1, 12, 15, 32, DateTimeZone.UTC).toDate
   val updated6: Date = new DateTime(2017, 9, 1, 12, 15, 32, DateTimeZone.UTC).toDate
+  val updated7: Date = new DateTime(2017, 9, 1, 12, 15, 32, DateTimeZone.UTC).toDate
   val created: Date = new DateTime(2017, 1, 1, 12, 15, 32, DateTimeZone.UTC).toDate
 
   val podcastSeries1: Series = Series(
@@ -176,6 +177,28 @@ class AudioSearchServiceTest
     Some(podcastSeries1)
   )
 
+  val audio7: AudioMetaInformation = AudioMetaInformation(
+    Some(7),
+    Some(1),
+    List(Title("Não relacionado", "pt-br")),
+    List(Audio("pt-br.mp3", "audio/mpeg", 1024, "pt-br")),
+    byNcSa,
+    List(Tag(List("wubbi"), "pt-br")),
+    "ndla123",
+    updated7,
+    created,
+    Seq(
+      domain.PodcastMeta(
+        introduction = "portugeseintro",
+        coverPhoto = domain.CoverPhoto("2", "meta"),
+        language = "pt-br"
+      )),
+    AudioType.Podcast,
+    Seq.empty,
+    Some(1),
+    None
+  )
+
   // Skip tests if no docker environment available
   override def withFixture(test: NoArgTest): Outcome = {
     assume(elasticSearchContainer.isSuccess)
@@ -190,6 +213,9 @@ class AudioSearchServiceTest
       .thenReturn(audio5.copy(copyright = audio5.copyright.copy(license = "gnu")))
 
     when(converterService.findAndConvertDomainToApiField(any, any, any)(any)).thenCallRealMethod()
+    when(converterService.toApiManuscript(any)).thenCallRealMethod()
+    when(converterService.toApiCoverPhoto(any)).thenCallRealMethod()
+    when(converterService.toApiPodcastMeta(any)).thenCallRealMethod()
 
     if (elasticSearchContainer.isSuccess) {
       audioIndexService.createIndexWithName(AudioApiProperties.SearchIndex)
@@ -199,8 +225,9 @@ class AudioSearchServiceTest
       audioIndexService.indexDocument(audio4)
       audioIndexService.indexDocument(audio5)
       audioIndexService.indexDocument(audio6)
+      audioIndexService.indexDocument(audio7)
 
-      blockUntil(() => audioSearchService.countDocuments == 6)
+      blockUntil(() => audioSearchService.countDocuments == 7)
     }
   }
 
@@ -229,7 +256,7 @@ class AudioSearchServiceTest
 
   test("That no language returns all documents ordered by title ascending") {
     val Success(results) = audioSearchService.matchingQuery(searchSettings.copy())
-    results.totalCount should be(5)
+    results.totalCount should be(6)
     results.results.head.id should be(4)
     results.results.last.id should be(6)
   }
@@ -244,15 +271,15 @@ class AudioSearchServiceTest
   test("That paging returns only hits on current page and not more than page-size") {
     val Success(page1) = audioSearchService.matchingQuery(searchSettings.copy(page = Some(1), pageSize = Some(2)))
     val Success(page2) = audioSearchService.matchingQuery(searchSettings.copy(page = Some(2), pageSize = Some(2)))
-    page1.totalCount should be(5)
+    page1.totalCount should be(6)
     page1.page.get should be(1)
     page1.results.size should be(2)
     page1.results.head.id should be(4)
-    page1.results.last.id should be(2)
-    page2.totalCount should be(5)
+    page1.results.last.id should be(7)
+    page2.totalCount should be(6)
     page2.page.get should be(2)
     page2.results.size should be(2)
-    page2.results.head.id should be(3)
+    page2.results.head.id should be(2)
   }
 
   test("That search matches title") {
@@ -401,7 +428,7 @@ class AudioSearchServiceTest
   test("That sorting by lastUpdated asc functions correctly") {
     val Success(search) = audioSearchService.matchingQuery(searchSettings.copy(sort = Sort.ByLastUpdatedAsc))
 
-    search.totalCount should be(5)
+    search.totalCount should be(6)
     search.results.head.id should be(5)
     search.results(1).id should be(3)
     search.results(2).id should be(2)
@@ -412,18 +439,19 @@ class AudioSearchServiceTest
   test("That sorting by lastUpdated desc functions correctly") {
     val Success(search) = audioSearchService.matchingQuery(searchSettings.copy(sort = Sort.ByLastUpdatedDesc))
 
-    search.totalCount should be(5)
+    search.totalCount should be(6)
     search.results.head.id should be(6)
-    search.results(1).id should be(4)
-    search.results(2).id should be(2)
-    search.results(3).id should be(3)
-    search.results(4).id should be(5)
+    search.results(1).id should be(7)
+    search.results(2).id should be(4)
+    search.results(3).id should be(2)
+    search.results(4).id should be(3)
+    search.results(5).id should be(5)
   }
 
   test("That sorting by id asc functions correctly") {
     val Success(search) = audioSearchService.matchingQuery(searchSettings.copy(sort = Sort.ByIdAsc))
 
-    search.totalCount should be(5)
+    search.totalCount should be(6)
     search.results.head.id should be(2)
     search.results(1).id should be(3)
     search.results(2).id should be(4)
@@ -434,12 +462,13 @@ class AudioSearchServiceTest
   test("That sorting by id desc functions correctly") {
     val Success(search) = audioSearchService.matchingQuery(searchSettings.copy(sort = Sort.ByIdDesc))
 
-    search.totalCount should be(5)
-    search.results.head.id should be(6)
-    search.results(1).id should be(5)
-    search.results(2).id should be(4)
-    search.results(3).id should be(3)
-    search.results(4).id should be(2)
+    search.totalCount should be(6)
+    search.results.head.id should be(7)
+    search.results(1).id should be(6)
+    search.results(2).id should be(5)
+    search.results(3).id should be(4)
+    search.results(4).id should be(3)
+    search.results(5).id should be(2)
   }
 
   test("That supportedLanguages are sorted correctly") {
@@ -449,7 +478,7 @@ class AudioSearchServiceTest
 
   test("That scrolling works as expected") {
     val pageSize = 2
-    val expectedIds = List(2, 3, 4, 5, 6).sliding(pageSize, pageSize).toList
+    val expectedIds = List(2, 3, 4, 5, 6, 7).sliding(pageSize, pageSize).toList
 
     val Success(initialSearch) =
       audioSearchService.matchingQuery(
@@ -467,13 +496,13 @@ class AudioSearchServiceTest
 
   test("That filtering for audio-type works as expected") {
     val Success(search1) = audioSearchService.matchingQuery(searchSettings.copy(audioType = None))
-    search1.totalCount should be(5)
+    search1.totalCount should be(6)
     search1.results.head.id should be(4)
     search1.results.last.id should be(6)
 
     val Success(search2) = audioSearchService.matchingQuery(searchSettings.copy(audioType = Some(AudioType.Podcast)))
-    search2.totalCount should be(1)
-    search2.results.map(_.id) should be(Seq(6))
+    search2.totalCount should be(2)
+    search2.results.map(_.id) should be(Seq(7, 6))
   }
 
   test("That searching matches manuscript") {
@@ -491,13 +520,13 @@ class AudioSearchServiceTest
 
     val Success(search2) =
       audioSearchService.matchingQuery(searchSettings.copy(seriesFilter = Some(false), sort = Sort.ByIdAsc))
-    search2.totalCount should be(4)
-    search2.results.map(_.id) should be(Seq(2, 3, 4, 5))
+    search2.totalCount should be(5)
+    search2.results.map(_.id) should be(Seq(2, 3, 4, 5, 7))
 
     val Success(search3) =
       audioSearchService.matchingQuery(searchSettings.copy(seriesFilter = None, sort = Sort.ByIdAsc))
-    search3.totalCount should be(5)
-    search3.results.map(_.id) should be(Seq(2, 3, 4, 5, 6))
+    search3.totalCount should be(6)
+    search3.results.map(_.id) should be(Seq(2, 3, 4, 5, 6, 7))
   }
 
   test("That searching for podcast meta introductions works") {

--- a/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
@@ -180,10 +180,10 @@ class AudioSearchServiceTest
   val audio7: AudioMetaInformation = AudioMetaInformation(
     Some(7),
     Some(1),
-    List(Title("Não relacionado", "pt-br")),
-    List(Audio("pt-br.mp3", "audio/mpeg", 1024, "pt-br")),
+    List(Title("Não relacionado", "pt-br"), Title("Dogosé", "dos")),
+    List(Audio("pt-br.mp3", "audio/mpeg", 1024, "pt-br"), Audio("pt-br.mp3", "audio/mpeg", 1024, "dos")),
     byNcSa,
-    List(Tag(List("wubbi"), "pt-br")),
+    List(Tag(List("wubbi"), "pt-br"), Tag(List("asdf"), "dos")),
     "ndla123",
     updated7,
     created,
@@ -192,7 +192,13 @@ class AudioSearchServiceTest
         introduction = "portugeseintro",
         coverPhoto = domain.CoverPhoto("2", "meta"),
         language = "pt-br"
-      )),
+      ),
+      domain.PodcastMeta(
+        introduction = "dogose intro",
+        coverPhoto = domain.CoverPhoto("1", "alt "),
+        language = "dos"
+      )
+    ),
     AudioType.Podcast,
     Seq.empty,
     Some(1),
@@ -373,6 +379,15 @@ class AudioSearchServiceTest
 
     result.results.last.title.title should be("Unrelated")
     result.results.last.title.language should be("en")
+  }
+
+  test("That searching for language not in predefind list should work") {
+    val Success(result) = audioSearchService.matchingQuery(searchSettings.copy(language = Some("dos")))
+    result.totalCount should be(1)
+    result.language should be("dos")
+
+    result.results.head.title.title should be("Dogosé")
+    result.results.head.title.language should be("dos")
   }
 
   test("That 'supported languages' should match all possible title languages") {

--- a/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/AudioSearchServiceTest.scala
@@ -355,7 +355,7 @@ class AudioSearchServiceTest
   }
 
   test("That searching for all languages and specifying no language should return the same") {
-    val Success(results1) = audioSearchService.matchingQuery(searchSettings.copy(language = Some("all")))
+    val Success(results1) = audioSearchService.matchingQuery(searchSettings.copy(language = Some("*")))
     val Success(results2) = audioSearchService.matchingQuery(searchSettings.copy(language = None))
 
     results1.totalCount should be(results2.totalCount)
@@ -381,13 +381,19 @@ class AudioSearchServiceTest
     result.results.last.title.language should be("en")
   }
 
-  test("That searching for language not in predefind list should work") {
+  test("That searching for language not in predefined list should work") {
     val Success(result) = audioSearchService.matchingQuery(searchSettings.copy(language = Some("dos")))
     result.totalCount should be(1)
     result.language should be("dos")
 
     result.results.head.title.title should be("Dogosé")
     result.results.head.title.language should be("dos")
+  }
+
+  test("That searching for language not in indexed data should not fail") {
+    val Success(result) = audioSearchService.matchingQuery(searchSettings.copy(language = Some("ait"))) //Arikem
+    result.totalCount should be(0)
+    result.language should be("ait")
   }
 
   test("That 'supported languages' should match all possible title languages") {
@@ -499,9 +505,9 @@ class AudioSearchServiceTest
       audioSearchService.matchingQuery(
         searchSettings.copy(pageSize = Some(pageSize), sort = Sort.ByIdAsc, shouldScroll = true))
 
-    val Success(scroll1) = audioSearchService.scroll(initialSearch.scrollId.get, "all")
-    val Success(scroll2) = audioSearchService.scroll(scroll1.scrollId.get, "all")
-    val Success(scroll3) = audioSearchService.scroll(scroll2.scrollId.get, "all")
+    val Success(scroll1) = audioSearchService.scroll(initialSearch.scrollId.get, "*")
+    val Success(scroll2) = audioSearchService.scroll(scroll1.scrollId.get, "*")
+    val Success(scroll3) = audioSearchService.scroll(scroll2.scrollId.get, "*")
 
     initialSearch.results.map(_.id) should be(expectedIds.head)
     scroll1.results.map(_.id) should be(expectedIds(1))

--- a/src/test/scala/no/ndla/audioapi/service/search/SearchConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/SearchConverterServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE

--- a/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
@@ -42,12 +42,16 @@ class SeriesSearchServiceTest
   val seriesToIndex = Seq(
     TestData.SampleSeries.copy(
       id = 1,
-      title = Seq(domain.Title("Lyd med epler", "nb")),
-      description = Seq(domain.Description("megabeskrivelse", "nb"))
+      title = Seq(domain.Title("Lyd med epler", "nb"), domain.Title("Sound with apples", "en")),
+      description = Seq(domain.Description("megabeskrivelse", "nb"), domain.Description("giant description", "en"))
     ),
     TestData.SampleSeries.copy(
       id = 2,
       title = Seq(domain.Title("Lyd med tiger", "nb"))
+    ),
+    TestData.SampleSeries.copy(
+      id = 3,
+      title = Seq(domain.Title("Lyd på språket Mixtepec Mixtec uten analyzer", "mix"))
     )
   )
 
@@ -76,15 +80,24 @@ class SeriesSearchServiceTest
     result1.results.map(_.id) should be(Seq(2))
 
     val Success(result2) = seriesSearchService.matchingQuery(settings.copy(query = Some("Lyd med")))
-    result2.results.map(_.id) should be(Seq(1, 2))
+    result2.results.map(_.id) should be(Seq(1, 2, 3))
 
     val Success(result3) = seriesSearchService.matchingQuery(settings.copy(query = Some("epler")))
     result3.results.map(_.id) should be(Seq(1))
+
+    val Success(result4) =
+      seriesSearchService.matchingQuery(settings.copy(query = Some("mixtepec"), language = Some("mix")))
+    result4.results.map(_.id) should be(Seq(3))
   }
 
   test("That descriptions are searchable") {
     val Success(result1) = seriesSearchService.matchingQuery(settings.copy(query = Some("megabeskrivelse")))
     result1.results.map(_.id) should be(Seq(1))
+
+    val Success(result2) =
+      seriesSearchService.matchingQuery(settings.copy(query = Some("description"), language = Some("en")))
+    result2.results.map(_.id) should be(Seq(1))
+
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/audioapi/service/search/SeriesSearchServiceTest.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA audio_api.
+ * Part of NDLA audio-api
  * Copyright (C) 2016 NDLA
  *
  * See LICENSE


### PR DESCRIPTION
Med denne pr har vi støtte for alle språk som er definerte i language-pakka, forka fra gdl. 

For å få til det måtte eg endre generering av mapping for indeksen. Før blei det lagt inn et felt titles med underfelt nb, nn, en og alle dei som fantes i lista med språk i Languages. Det begrensa mulige språk til dei predefinerte der. For å kunne støtte alle mogelige språk måtte eg bruke dynamic templates. Disse er definerte basert på lista med språk i Languages, men med en template som dekker resten av mogelege språk.

Må koorddineres med alle apiene med språkhåndtering slik at alle deployes på likt med ed, fordi unknown forsvinner som godkjent språkkode etter dette. Indeks må også genereres fordi ny indeks ikkje er kompatibel med den gamle.