### PR TITLE
2794 Fikse sletting av podkastepisoder

### DIFF
--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -145,7 +145,8 @@ trait WriteService {
               deleteFile(removedFilePath)
             } else Success(())
 
-            deleteResult.flatMap(_ => validateAndUpdateMetaData(audioId, newAudio, existing, None, existing.seriesId).map(Some(_)))
+            deleteResult.flatMap(_ =>
+              validateAndUpdateMetaData(audioId, newAudio, existing, None, existing.seriesId).map(Some(_)))
 
           }
 

--- a/src/main/scala/no/ndla/audioapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/audioapi/service/WriteService.scala
@@ -145,7 +145,7 @@ trait WriteService {
               deleteFile(removedFilePath)
             } else Success(())
 
-            deleteResult.flatMap(_ => validateAndUpdateMetaData(audioId, newAudio, existing, None, None).map(Some(_)))
+            deleteResult.flatMap(_ => validateAndUpdateMetaData(audioId, newAudio, existing, None, existing.seriesId).map(Some(_)))
 
           }
 


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2794
Den tidligere utgaven av slette-funksjonaliteten passerte alltid inn `None` som `seriesId`, som førte til at validerings-sjekken på om serien eksisterte alltid ville feile. 